### PR TITLE
fix: qa fixes for tool-test-action-on-github

### DIFF
--- a/tool-test-action-on-github/test-action-on-github-data/base-lecture-fa.md
+++ b/tool-test-action-on-github/test-action-on-github-data/base-lecture-fa.md
@@ -8,6 +8,7 @@ kernelspec:
   language: python
   name: python3
 heading-map:
+  Linear Algebra Foundations: مبانی جبر خطی
   Vector Spaces: فضاهای برداری
   Vector Spaces::Basic Properties: ویژگی‌های اساسی
   Vector Spaces::Basic Properties::Applications in Economics: کاربردها در اقتصاد

--- a/tool-test-action-on-github/test-action-on-github-data/base-minimal-fa.md
+++ b/tool-test-action-on-github/test-action-on-github-data/base-minimal-fa.md
@@ -8,6 +8,7 @@ kernelspec:
   language: python
   name: python3
 heading-map:
+  Introduction to Economics: مقدمه‌ای بر اقتصاد
   Supply and Demand: عرضه و تقاضا
   Economic Models: مدل‌های اقتصادی
 ---

--- a/tool-test-action-on-github/test-action-on-github-data/workflow-template.yml
+++ b/tool-test-action-on-github/test-action-on-github-data/workflow-template.yml
@@ -34,12 +34,10 @@ jobs:
         id: mode
         run: |
           if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
-            echo "mode=production" >> $GITHUB_OUTPUT
-            echo "commit_sha=${{ github.event.pull_request.merge_commit_sha }}" >> $GITHUB_OUTPUT
+            echo "test-mode=false" >> $GITHUB_OUTPUT
             echo "🚀 Running in PRODUCTION mode (merged PR)"
           else
-            echo "mode=test" >> $GITHUB_OUTPUT
-            echo "commit_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "test-mode=true" >> $GITHUB_OUTPUT
             echo "🧪 Running in TEST mode (test-translation label)"
           fi
       
@@ -53,4 +51,4 @@ jobs:
           docs-folder: '.'
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          test-mode: ${{ steps.mode.outputs.mode == 'test' }}
+          test-mode: ${{ steps.mode.outputs.test-mode }}

--- a/tool-test-action-on-github/test-action-on-github.sh
+++ b/tool-test-action-on-github/test-action-on-github.sh
@@ -217,7 +217,7 @@ else
 
     # Reset to base state
     echo "Resetting to base state..."
-    rm -rf *.md *.yml lectures/
+    rm -rf *.md *.yml lectures/ .translate/
     cp "$DATA_DIR/base-minimal-zh-cn.md" "$TEST_FILE_MINIMAL"
     cp "$DATA_DIR/base-lecture-zh-cn.md" "$TEST_FILE_LECTURE"
     cp "$DATA_DIR/base-toc-zh-cn.yml" "_toc.yml"


### PR DESCRIPTION
## Summary

Quality-check fixes for `tool-test-action-on-github` following the Farsi language support added in commit `85afafa` (feat: add Farsi target to test-action-on-github tool, merged directly to main).

## Issues Fixed

### 1. Missing top-level heading-map entries in Farsi base files

Both Farsi base files were missing the document-level heading mapping, which caused the action to add it as a new change on every test run (making it look like unintended heading-map churn).

- `base-minimal-fa.md`: added `Introduction to Economics: مقدمه‌ای بر اقتصاد`
- `base-lecture-fa.md`: added `Linear Algebra Foundations: مبانی جبر خطی`

### 2. zh-cn target reset not clearing `.translate/`

The zh-cn reset step used `rm -rf *.md *.yml lectures/` but did not remove `.translate/`. If any translation PRs were ever merged into the zh-cn target, stale state files would carry over into subsequent test runs, skewing UPDATE vs NEW mode behaviour.

Fixed: `rm -rf *.md *.yml lectures/ .translate/` (mirrors the fa reset, which already did this correctly).

### 3. workflow-template.yml (zh-cn) inconsistencies

- Removed unused `commit_sha` outputs that were set in the `Determine mode` step but never referenced
- Aligned `test-mode` pattern with the fa template: use explicit `echo "test-mode=true/false"` outputs instead of the YAML expression `${{ steps.mode.outputs.mode == 'test' }}`
