### PR TITLE
fix: preserve model metadata in --write-state, standardize model refs

### DIFF
--- a/src/__tests__/e2e-fixtures.test.ts
+++ b/src/__tests__/e2e-fixtures.test.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 // Mock translator that returns predictable Chinese
 class MockTranslator extends TranslationService {
   constructor() {
-    super('test-key', 'claude-sonnet-4.5-20241022', false);
+    super('test-key', 'claude-sonnet-4-6', false);
   }
 
   async translateSection(request: any): Promise<any> {

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -22,7 +22,7 @@ import * as path from 'path';
 class MockTranslationService extends TranslationService {
   constructor() {
     // Use dummy values - we'll override the methods
-    super('test-api-key', 'claude-sonnet-4.5-20241022', false);
+    super('test-api-key', 'claude-sonnet-4-6', false);
   }
   
   /**

--- a/src/cli/__tests__/status.test.ts
+++ b/src/cli/__tests__/status.test.ts
@@ -18,6 +18,7 @@ import {
   formatStatusJson,
   FileSyncStatus,
 } from '../commands/status.js';
+import { readFileState, writeFileState } from '../translate-state.js';
 
 // ============================================================================
 // HELPERS
@@ -616,6 +617,55 @@ describe('--write-state safeguard', () => {
       apiKey: 'test-key',
       testMode: true,
     })).rejects.toThrow('cannot be used together');
+  });
+
+  it('should preserve model from existing state file instead of overwriting with unknown', async () => {
+    const sourceDir = path.join(tmpDir, 'source', 'lectures');
+    const targetDir = path.join(tmpDir, 'target', 'lectures');
+    writeMd(path.join(sourceDir, 'intro.md'), SOURCE_2_SECTIONS);
+    writeMd(path.join(targetDir, 'intro.md'), TARGET_2_SECTIONS_WITH_MAP);
+
+    // Pre-seed a state file (as forward would)
+    writeFileState(path.join(tmpDir, 'target'), 'intro.md', {
+      'source-sha': 'abc123',
+      'synced-at': '2026-03-01',
+      model: 'claude-sonnet-4-20250514',
+      mode: 'RESYNC',
+      'section-count': 2,
+    });
+
+    // --write-state should preserve the existing model
+    await runStatus({
+      source: path.join(tmpDir, 'source'),
+      target: path.join(tmpDir, 'target'),
+      docsFolder: 'lectures',
+      language: 'zh-cn',
+      exclude: [],
+      writeState: true,
+    });
+
+    const state = readFileState(path.join(tmpDir, 'target'), 'intro.md');
+    expect(state?.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('should write unknown model when no existing state file exists', async () => {
+    const sourceDir = path.join(tmpDir, 'source', 'lectures');
+    const targetDir = path.join(tmpDir, 'target', 'lectures');
+    writeMd(path.join(sourceDir, 'intro.md'), SOURCE_2_SECTIONS);
+    writeMd(path.join(targetDir, 'intro.md'), TARGET_2_SECTIONS_WITH_MAP);
+
+    // No pre-existing state file
+    await runStatus({
+      source: path.join(tmpDir, 'source'),
+      target: path.join(tmpDir, 'target'),
+      docsFolder: 'lectures',
+      language: 'zh-cn',
+      exclude: [],
+      writeState: true,
+    });
+
+    const state = readFileState(path.join(tmpDir, 'target'), 'intro.md');
+    expect(state?.model).toBe('unknown');
   });
 });
 

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -373,10 +373,16 @@ export async function runStatus(options: StatusOptions): Promise<StatusResult> {
         const sourceContent = fs.readFileSync(sourceFilePath, 'utf-8');
         const parsed = await parser.parseSections(sourceContent, sourceFilePath);
 
+        // Preserve model from existing state if it was set by a prior command (e.g. forward)
+        const existingState = readFileState(target, entry.file);
+        const model = (existingState?.model && existingState.model !== 'unknown')
+          ? existingState.model
+          : 'unknown';
+
         writeFileState(target, entry.file, {
           'source-sha': sourceGit?.lastCommit ?? 'unknown',
           'synced-at': targetGit?.lastModified?.toISOString().split('T')[0] ?? new Date().toISOString().split('T')[0],
-          model: 'unknown',
+          model,
           mode: 'RESYNC',
           'section-count': parsed.sections.length,
         });


### PR DESCRIPTION
## Problem

`--write-state` always writes `model: 'unknown'` to every state file, even when a prior command (like `forward`) already wrote the actual model name. This happens because `--write-state` is a bootstrap operation designed for pre-existing translations where the original model can't be recovered — but it doesn't check for existing state that was written in earlier workflow steps.

Additionally, two test files used a stale model name (`claude-sonnet-4.5-20241022`) that doesn't match any valid pattern and wouldn't pass the input validator.

## Changes

**`src/cli/commands/status.ts`** — `--write-state` now reads existing state files before writing. If the `model` field is already set to something other than `unknown` (e.g. written by `forward`), it preserves that value.

**`src/__tests__/integration.test.ts`**, **`src/__tests__/e2e-fixtures.test.ts`** — Updated mock model names from `claude-sonnet-4.5-20241022` to `claude-sonnet-4-6` for consistency.

**`src/cli/__tests__/status.test.ts`** — Added 2 tests:
- Preserves model from existing state file
- Writes `unknown` when no prior state exists

## Audit summary

All production code defaults are consistent on `claude-sonnet-4-6`:
- `inputs.ts` (Action defaults)
- `translator.ts` (constructor default)
- `reviewer.ts` (`DEFAULT_REVIEW_MODEL`)
- `cli/index.ts` (all 3 commands with `--model` flag)
- `cli/commands/status.ts` (`--check-sync` default)

900 tests pass (39 suites).
