### PR TITLE
fix: CJK–MyST spacing rule and target-label blank-line cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@
 - **Sync Mode**: Runs in SOURCE repo, creates translation PRs in target repo
 - **Review Mode**: Runs in TARGET repo, posts quality review comments on translation PRs
 
-**Current Version**: v0.12.3 | **Tests**: 934 (39 suites) | **Glossary**: 357 terms (zh-cn, fa)
+**Current Version**: v0.12.3 | **Tests**: 935 (39 suites) | **Glossary**: 357 terms (zh-cn, fa)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CJK–MyST spacing rule for zh-cn**: New language-config rule instructs Claude to insert a space between Chinese characters and inline MyST directives (`{doc}`, `{ref}`, etc.) or Markdown links, preventing rendering failures (e.g. `请参阅 {doc}` not `请参阅{doc}`)
+- **MyST target-label blank-line cleanup**: `reconstructFromComponents` now strips blank lines between MyST target labels (`(label)=`) and headings in post-processing, so targets always attach to their heading correctly
+- **1 test** for target-label blank-line removal (934 → 935 total)
+
 ## [0.12.3] - 2026-03-24
 
 ### Fixed

--- a/src/__tests__/component-reconstruction.test.ts
+++ b/src/__tests__/component-reconstruction.test.ts
@@ -1615,4 +1615,93 @@ heading-map:
     expect(result).toContain('Section B: B部分');
     expect(result).not.toContain('Section A:');
   });
+
+  it('should remove blank lines between MyST target labels and headings', async () => {
+    const oldContent = `---
+config: test
+---
+
+# Advanced Features
+
+Overview paragraph.
+
+## Iterables
+
+Content about iterables.
+
+(iterators)=
+### Iterators
+
+Iterator details.
+
+(descriptors)=
+## Decorators
+
+Decorator content.`;
+
+    const newContent = `---
+config: test
+---
+
+# Advanced Features
+
+Overview paragraph updated.
+
+## Iterables
+
+Content about iterables.
+
+(iterators)=
+### Iterators
+
+Iterator details.
+
+(descriptors)=
+## Decorators
+
+Decorator content.`;
+
+    const targetContent = `---
+config: test
+---
+
+# 高级特性
+
+概述段落。
+
+## 可迭代对象
+
+关于可迭代对象的内容。
+
+(iterators)=
+### 迭代器
+
+迭代器详情。
+
+(descriptors)=
+## 装饰器
+
+装饰器内容。`;
+
+    // Mock translation for intro change
+    mockTranslator.translateSection.mockResolvedValue({
+      success: true,
+      translatedSection: '概述段落已更新。',
+    });
+
+    const result = await processor.processSectionBased(
+      oldContent,
+      newContent,
+      targetContent,
+      'test.md',
+      'en',
+      'zh-cn'
+    );
+
+    // Target labels should be directly above headings with no blank line
+    expect(result).toContain('(iterators)=\n### 迭代器');
+    expect(result).not.toContain('(iterators)=\n\n### 迭代器');
+    expect(result).toContain('(descriptors)=\n## 装饰器');
+    expect(result).not.toContain('(descriptors)=\n\n## 装饰器');
+  });
 });

--- a/src/__tests__/language-config.test.ts
+++ b/src/__tests__/language-config.test.ts
@@ -17,8 +17,9 @@ describe('Language Configuration', () => {
       const config = getLanguageConfig('zh-cn');
       expect(config.code).toBe('zh-cn');
       expect(config.name).toBe('Chinese (Simplified)');
-      expect(config.additionalRules).toHaveLength(1);
+      expect(config.additionalRules).toHaveLength(2);
       expect(config.additionalRules[0]).toContain('full-width Chinese punctuation');
+      expect(config.additionalRules[1]).toContain('space between Chinese characters and inline MyST directives');
     });
 
     it('should handle case insensitive language codes', () => {

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -489,7 +489,12 @@ export class FileProcessor {
       parts.push(''); // Empty line between sections
     }
 
-    return parts.join('\n').trim() + '\n';
+    const joined = parts.join('\n').trim() + '\n';
+
+    // Post-process: remove blank lines between MyST target labels and headings.
+    // Target labels like (some_id)= must be directly above their heading with no
+    // intervening blank line, otherwise MyST won't attach the target to the heading.
+    return joined.replace(/(\([a-zA-Z0-9_.:-]+\)=)\n\n(#+\s)/g, '$1\n$2');
   }
 
   /**

--- a/src/language-config.ts
+++ b/src/language-config.ts
@@ -33,6 +33,7 @@ export const LANGUAGE_CONFIGS: Record<string, LanguageConfig> = {
     name: 'Chinese (Simplified)',
     additionalRules: [
       'Use proper full-width Chinese punctuation marks (，：。！？) not ASCII punctuation (,.!?) in prose text',
+      'Always insert a space between Chinese characters and inline MyST directives ({doc}, {ref}, {any}, {term}, etc.) or Markdown links ([text](url)), e.g., "请参阅 {doc}\`介绍 <intro>\`" not "请参阅{doc}\`介绍 <intro>\`"',
     ],
   },
   'fa': {


### PR DESCRIPTION
Address feedback from [lecture-python-programming.zh-cn PR #6](https://github.com/QuantEcon/lecture-python-programming.zh-cn/pull/6) (HumphreyYang).

## Changes

### 1. CJK–MyST spacing rule (zh-cn language config)

New `additionalRules` entry instructs Claude to always insert a space between Chinese characters and inline MyST directives (`{doc}`, `{ref}`, `{any}`, `{term}`, etc.) or Markdown links (`[text](url)`).

**Before**: `请参阅{doc}` — directive may not render  
**After**: `请参阅 {doc}` — renders correctly

### 2. MyST target-label blank-line cleanup (file-processor)

`reconstructFromComponents` now post-processes the joined document to strip blank lines between MyST target labels (`(label)=`) and headings. The section separator logic was inserting blank lines that break MyST target-to-heading attachment.

**Before**:
```
(paf_generators)=

## 生成器
```

**After**:
```
(paf_generators)=
## 生成器
```

## Files Changed

| File | Change |
|------|--------|
| `src/language-config.ts` | Add spacing rule to zh-cn config |
| `src/file-processor.ts` | Post-process to strip blank lines between targets and headings |
| `src/__tests__/language-config.test.ts` | Update to expect 2 rules |
| `src/__tests__/component-reconstruction.test.ts` | New test for target-label cleanup |
| `CHANGELOG.md` | Add unreleased entries |
| `.github/copilot-instructions.md` | Update test count 934 → 935 |
