### PR TITLE
fix: retry on Anthropic overloaded_error

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -138,6 +138,24 @@ gh release create vX.Y.Z --title "..." --notes-file .tmp/release-notes.md > .tmp
 
 The `.tmp/` folder is committed (via `.gitkeep`) but its contents are git-ignored.
 
+### Addressing Copilot PR Review Comments
+
+After pushing a PR, Copilot may leave review comments. To address them:
+
+1. **Fetch review comments** — get comment IDs:
+   ```bash
+   gh api repos/QuantEcon/action-translation/pulls/PR_NUM/comments \
+     --jq '.[] | {id, path, line, body: (.body | split("\n")[0])}' \
+     > .tmp/pr-comments.txt && cat .tmp/pr-comments.txt
+   ```
+2. **Push fixes** to the PR branch addressing the feedback
+3. **Reply to each comment** — write reply to a file, then post:
+   ```bash
+   gh api repos/QuantEcon/action-translation/pulls/PR_NUM/comments/COMMENT_ID/replies \
+     -f body="$(cat .tmp/reply.txt)" 2>&1 | jq -r '.html_url'
+   ```
+4. **Resolve threads** on the GitHub web interface
+
 ---
 
 ## E2E Testing Tool (`tool-test-action-on-github/`)

--- a/src/__tests__/translator-retry.test.ts
+++ b/src/__tests__/translator-retry.test.ts
@@ -128,6 +128,15 @@ function badRequestError(msg: string) {
 function serverError(status: number, msg: string) {
   return new APIError(status, undefined, msg, null as any);
 }
+
+function overloadedError() {
+  return new APIError(
+    undefined,
+    { type: 'error', error: { type: 'overloaded_error', message: 'Overloaded' } },
+    '{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}',
+    null as any,
+  );
+}
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 // Speed up tests by reducing retry delays
@@ -232,6 +241,40 @@ describe('TranslationService - Retry Logic', () => {
 
       expect(result.success).toBe(true);
       expect(mockStream).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry on overloaded_error (APIError with undefined status) and succeed', async () => {
+      mockFinalMessage
+        .mockRejectedValueOnce(overloadedError())
+        .mockResolvedValueOnce(createSuccessResponse());
+
+      const result = await service.translateSection({
+        mode: 'new',
+        sourceLanguage: 'en',
+        targetLanguage: 'zh-cn',
+        englishSection: '## Test\n\nContent',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockStream).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fail after max retries on persistent overloaded_error', async () => {
+      mockFinalMessage
+        .mockRejectedValueOnce(overloadedError())
+        .mockRejectedValueOnce(overloadedError())
+        .mockRejectedValueOnce(overloadedError());
+
+      const result = await service.translateSection({
+        mode: 'new',
+        sourceLanguage: 'en',
+        targetLanguage: 'zh-cn',
+        englishSection: '## Test\n\nContent',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('overloaded');
+      expect(mockStream).toHaveBeenCalledTimes(3);
     });
 
     it('should retry up to maxRetries times then fail', async () => {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -101,6 +101,9 @@ function formatApiError(error: unknown): string {
     return `Bad request: ${error.message}. This may indicate an issue with the prompt or content.`;
   }
   if (error instanceof APIError) {
+    if (error.message?.includes('overloaded')) {
+      return 'Anthropic API is temporarily overloaded. The action will retry automatically.';
+    }
     return `API error (${error.status}): ${error.message}`;
   }
   if (error instanceof Error) {
@@ -166,7 +169,10 @@ export class TranslationService {
         const isRetryable =
           error instanceof RateLimitError ||
           error instanceof APIConnectionError ||
-          (error instanceof APIError && error.status !== undefined && error.status >= 500);
+          (error instanceof APIError && (
+            (error.status !== undefined && error.status >= 500) ||
+            error.status === undefined  // overloaded_error has no HTTP status
+          ));
 
         if (!isRetryable || attempt === maxRetries) {
           throw error;

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -102,7 +102,7 @@ function formatApiError(error: unknown): string {
   }
   if (error instanceof APIError) {
     if (error.message?.includes('overloaded')) {
-      return 'Anthropic API is temporarily overloaded. The action will retry automatically.';
+      return 'Anthropic API is temporarily overloaded. Retries exhausted — please try again later.';
     }
     return `API error (${error.status}): ${error.message}`;
   }
@@ -143,6 +143,7 @@ export class TranslationService {
    * - RateLimitError (429)
    * - APIConnectionError (network issues)
    * - APIError with 5xx status (server errors)
+   * - APIError with overloaded_error (status undefined)
    *
    * Does NOT retry on:
    * - AuthenticationError (invalid API key)
@@ -171,7 +172,7 @@ export class TranslationService {
           error instanceof APIConnectionError ||
           (error instanceof APIError && (
             (error.status !== undefined && error.status >= 500) ||
-            error.status === undefined  // overloaded_error has no HTTP status
+            (error.status === undefined && error.message?.includes('overloaded'))  // overloaded_error
           ));
 
         if (!isRetryable || attempt === maxRetries) {


### PR DESCRIPTION
## Summary

Fixes #57 — `overloaded_error` from the Anthropic API was not retried, causing sync failures.

## Changes

**`src/translator.ts`**
- Broadened the retry condition in `callWithRetry` to treat any `APIError` with `status: undefined` as retryable (the `overloaded_error` has no HTTP status code)
- Improved `formatApiError` to return a clear user-facing message for overloaded errors

**`src/__tests__/translator-retry.test.ts`**
- Added `overloadedError()` helper matching the real SDK error shape
- Added test: retry on `overloaded_error` and succeed on second attempt
- Added test: fail after max retries on persistent `overloaded_error`
