### PR TITLE
feat: support language-targeted \translate-resync command

### DIFF
--- a/src/__tests__/inputs.test.ts
+++ b/src/__tests__/inputs.test.ts
@@ -416,9 +416,10 @@ describe('validatePREvent (sync mode)', () => {
       expect(result.prNumber).toBe(42);
       expect(result.isTestMode).toBe(false);
       expect(result.isResync).toBe(true);
+      expect(result.resyncLanguage).toBeUndefined();
     });
 
-    it('should accept \translate-resync with trailing text as language argument', () => {
+    it('should ignore unsupported language in trailing text (all-language resync)', () => {
       const context = {
         eventName: 'issue_comment',
         payload: {
@@ -437,7 +438,7 @@ describe('validatePREvent (sync mode)', () => {
       const result = validatePREvent(context, false);
       expect(result.isResync).toBe(true);
       expect(result.prNumber).toBe(42);
-      expect(result.resyncLanguage).toBe('please');
+      expect(result.resyncLanguage).toBeUndefined();
     });
 
     it('should parse language target from \translate-resync fa', () => {

--- a/src/__tests__/inputs.test.ts
+++ b/src/__tests__/inputs.test.ts
@@ -418,7 +418,7 @@ describe('validatePREvent (sync mode)', () => {
       expect(result.isResync).toBe(true);
     });
 
-    it('should accept \\translate-resync with trailing text', () => {
+    it('should accept \translate-resync with trailing text as language argument', () => {
       const context = {
         eventName: 'issue_comment',
         payload: {
@@ -437,6 +437,71 @@ describe('validatePREvent (sync mode)', () => {
       const result = validatePREvent(context, false);
       expect(result.isResync).toBe(true);
       expect(result.prNumber).toBe(42);
+      expect(result.resyncLanguage).toBe('please');
+    });
+
+    it('should parse language target from \translate-resync fa', () => {
+      const context = {
+        eventName: 'issue_comment',
+        payload: {
+          action: 'created',
+          issue: {
+            number: 42,
+            pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/42' },
+          },
+          comment: {
+            body: '\\translate-resync fa',
+            author_association: 'COLLABORATOR',
+          },
+        },
+      };
+
+      const result = validatePREvent(context, false);
+      expect(result.isResync).toBe(true);
+      expect(result.prNumber).toBe(42);
+      expect(result.resyncLanguage).toBe('fa');
+    });
+
+    it('should parse language target from \translate-resync zh-cn', () => {
+      const context = {
+        eventName: 'issue_comment',
+        payload: {
+          action: 'created',
+          issue: {
+            number: 42,
+            pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/42' },
+          },
+          comment: {
+            body: '\\translate-resync zh-cn',
+            author_association: 'MEMBER',
+          },
+        },
+      };
+
+      const result = validatePREvent(context, false);
+      expect(result.isResync).toBe(true);
+      expect(result.resyncLanguage).toBe('zh-cn');
+    });
+
+    it('should lowercase the language argument', () => {
+      const context = {
+        eventName: 'issue_comment',
+        payload: {
+          action: 'created',
+          issue: {
+            number: 42,
+            pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/42' },
+          },
+          comment: {
+            body: '\\translate-resync FA',
+            author_association: 'MEMBER',
+          },
+        },
+      };
+
+      const result = validatePREvent(context, false);
+      expect(result.isResync).toBe(true);
+      expect(result.resyncLanguage).toBe('fa');
     });
 
     it('should ignore comments not starting with \\translate-resync (no-op)', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,10 +120,16 @@ async function runSync(): Promise<void> {
 
     // Validate this is a merged PR event, test mode, or resync comment
     core.info('Validating PR event...');
-    const { merged, prNumber, isTestMode, isResync } = validatePREvent(github.context, inputs.testMode);
+    const { merged, prNumber, isTestMode, isResync, resyncLanguage } = validatePREvent(github.context, inputs.testMode);
 
     if (!merged) {
       core.info('PR was not merged. Exiting.');
+      return;
+    }
+
+    // If resync targets a specific language, skip if this workflow doesn't match
+    if (isResync && resyncLanguage && resyncLanguage !== inputs.targetLanguage) {
+      core.info(`Resync requested for '${resyncLanguage}', skipping (this workflow targets '${inputs.targetLanguage}').`);
       return;
     }
 

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -158,6 +158,7 @@ export interface PREventResult {
   prNumber: number;
   isTestMode: boolean;
   isResync: boolean;
+  resyncLanguage?: string;
 }
 
 /** The magic comment that triggers a resync */
@@ -248,6 +249,10 @@ function validateResyncComment(payload: any): PREventResult {
     return noOp;
   }
 
+  // Parse optional language argument: \translate-resync fa
+  const parts = commentBody.split(/\s+/);
+  const resyncLanguage = parts.length > 1 ? parts[1].toLowerCase() : undefined;
+
   // Authorization: only trusted actors can trigger resync
   const association = payload.comment?.author_association || '';
   if (!TRUSTED_ASSOCIATIONS.has(association)) {
@@ -265,8 +270,12 @@ function validateResyncComment(payload: any): PREventResult {
 
   // Note: issue_comment payload doesn't include merged status directly.
   // The caller (runSync) will verify the PR is merged via API.
-  core.info(`🔄 RESYNC triggered by comment on PR #${prNumber}`);
-  return { merged: true, prNumber, isTestMode: false, isResync: true };
+  if (resyncLanguage) {
+    core.info(`🔄 RESYNC triggered by comment on PR #${prNumber} for language '${resyncLanguage}'`);
+  } else {
+    core.info(`🔄 RESYNC triggered by comment on PR #${prNumber} (all languages)`);
+  }
+  return { merged: true, prNumber, isTestMode: false, isResync: true, resyncLanguage };
 }
 
 /**

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -251,7 +251,16 @@ function validateResyncComment(payload: any): PREventResult {
 
   // Parse optional language argument: \translate-resync fa
   const parts = commentBody.split(/\s+/);
-  const resyncLanguage = parts.length > 1 ? parts[1].toLowerCase() : undefined;
+  const requestedLang = parts.length > 1 ? parts[1].toLowerCase() : undefined;
+  const supportedLanguages = new Set(getSupportedLanguages());
+  const resyncLanguage = requestedLang && supportedLanguages.has(requestedLang) ? requestedLang : undefined;
+
+  if (requestedLang && !resyncLanguage) {
+    core.warning(
+      `Ignoring unsupported language '${requestedLang}' in ${RESYNC_COMMAND}. ` +
+      'Proceeding with resync for all languages.'
+    );
+  }
 
   // Authorization: only trusted actors can trigger resync
   const association = payload.comment?.author_association || '';


### PR DESCRIPTION
## Summary

Fixes #58 — support an optional language suffix on `\translate-resync` so only the targeted workflow runs.

## Changes

**`src/inputs.ts`**
- Added `resyncLanguage?: string` to `PREventResult`
- `validateResyncComment` now splits the comment body and extracts the first word after `\translate-resync` as the language target (lowercased)
- Log message distinguishes targeted vs. all-language resync

**`src/index.ts`**
- `runSync` destructures `resyncLanguage` from the event result
- If `resyncLanguage` is set and doesn't match `inputs.targetLanguage`, the workflow exits early with a clear log message

**`src/__tests__/inputs.test.ts`**
- Added 4 new tests: `fa` target, `zh-cn` target, case normalization, bare `\translate-resync` returns `undefined`
- Updated existing trailing-text test to verify `resyncLanguage` is parsed

## Behavior

| Comment | Effect |
|---------|--------|
| `\translate-resync` | Retriggers all language workflows (backward compatible) |
| `\translate-resync fa` | Only the Farsi workflow runs; others exit early |
| `\translate-resync zh-cn` | Only the zh-cn workflow runs; others exit early |
