### PR TITLE
fix: inject heading-map for new files + fix MISSING_HEADINGMAP false positive

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@
 - **Sync Mode**: Runs in SOURCE repo, creates translation PRs in target repo
 - **Review Mode**: Runs in TARGET repo, posts quality review comments on translation PRs
 
-**Current Version**: v0.14.0 | **Tests**: 972 (39 suites) | **Glossary**: 357 terms (zh-cn, fa)
+**Current Version**: v0.14.0 | **Tests**: 976 (39 suites) | **Glossary**: 357 terms (zh-cn, fa)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Heading-map injection for new files**: `processFull()` now builds and injects a `translation:` frontmatter block (heading-map + title) into newly translated files. Previously, only section-based updates via `processSectionBased` got heading-maps; new files were missing them.
+- **`MISSING_HEADINGMAP` false positive for title-only files**: `translate status` no longer flags files with no `##` sections as missing a heading-map. These files have only a title — an empty heading-map is expected.
+
+### Added
+- **4 tests**: 3 for `processFull` heading-map injection, 1 for title-only status check (972 → 976 total)
+
 ## [0.14.0] - 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
           github-token: ${{ secrets.TRANSLATION_PAT }}
 ```
 
-The `issue_comment` trigger enables the `\translate-resync` command — comment it on any merged PR to re-trigger sync (useful for recovering from failures).
+The `issue_comment` trigger enables the `\translate-resync` command — comment it on any merged PR to re-trigger sync (useful for recovering from failures). To retrigger only one language, add the code: `\translate-resync fa` or `\translate-resync zh-cn`.
 
 ### CLI
 

--- a/docs/user/action-reference.md
+++ b/docs/user/action-reference.md
@@ -121,7 +121,7 @@ jobs:
           github-token: ${{ secrets.TRANSLATION_PAT }}
 ```
 
-The `issue_comment` trigger enables the `\translate-resync` command — comment it on any merged PR to retry a failed sync.
+The `issue_comment` trigger enables the `\translate-resync` command — comment it on any merged PR to retry a failed sync. To retrigger only one language, add the language code: `\translate-resync fa` or `\translate-resync zh-cn`. Bare `\translate-resync` retriggers all languages.
 
 ### Multi-language sync
 
@@ -234,7 +234,7 @@ When a PR is merged, sync mode:
 8. **Creates a PR** — Commits all updated files to a branch in the target repo
 9. **Posts a success comment** — Confirms sync completion on the source PR with a link to the translation PR
 
-If any files fail to process, the action opens a GitHub Issue with error details and a link to the source PR. Comment `\translate-resync` on the merged PR to retry.
+If any files fail to process, the action opens a GitHub Issue with error details and a link to the source PR. Comment `\translate-resync` on the merged PR to retry all languages, or `\translate-resync fa` to retry a specific language.
 
 For new files, the entire document is translated in a single call (NEW mode).
 

--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -47,10 +47,19 @@ Check that:
 
 Yes. Comment `\translate-resync` on the **merged** PR in the source repo. The workflow will re-run the sync for that PR's changed files.
 
+To retrigger only a specific language, add the language code:
+
+```
+\translate-resync fa        # retrigger Farsi only
+\translate-resync zh-cn     # retrigger Chinese only
+\translate-resync            # retrigger all languages (default)
+```
+
 Requirements:
 - The workflow must include the `issue_comment` trigger (see [Action Reference](action-reference.md) for the YAML)
 - The PR must be merged (resync on open PRs is ignored)
 - The comment body must start with `\translate-resync`
+- The language code (if provided) must match a supported language; unsupported values are ignored with a warning and fall back to all-language resync
 
 For drift recovery beyond a single PR, use the CLI `forward` command instead — it works on any file regardless of PR history.
 
@@ -62,7 +71,7 @@ When the sync workflow encounters an error (API failure, parsing error, etc.), i
 - Recovery instructions including the `\translate-resync` command
 - The label `translation-sync-failure`
 
-To recover, fix the underlying issue and comment `\translate-resync` on the original merged PR.
+To recover, fix the underlying issue and comment `\translate-resync` on the original merged PR. To retry only a specific language, use `\translate-resync zh-cn` or `\translate-resync fa`.
 
 ### Does the action post any status updates?
 

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -60,7 +60,7 @@ jobs:
           github-token: ${{ secrets.TRANSLATION_PAT }}
 ```
 
-This workflow triggers whenever a PR that touches Markdown files in `lectures/` is merged. It detects which sections changed and creates a translation PR in the target repository. The `issue_comment` trigger enables re-syncing by commenting `\translate-resync` on a merged PR.
+This workflow triggers whenever a PR that touches Markdown files in `lectures/` is merged. It detects which sections changed and creates a translation PR in the target repository. The `issue_comment` trigger enables re-syncing by commenting `\translate-resync` on a merged PR. To retrigger only one language, add the language code (e.g., `\translate-resync zh-cn`).
 
 ## Step 3: Add the review workflow (optional)
 
@@ -104,7 +104,7 @@ This posts an AI-generated quality review comment on each translation PR, includ
 4. **The review workflow** (if configured) automatically reviews the translation PR and posts quality feedback
 5. **A human reviewer** approves and merges the translation PR
 
-If the sync fails, the action automatically opens a GitHub Issue with error details and recovery instructions. You can re-run the sync by commenting `\translate-resync` on the merged PR.
+If the sync fails, the action automatically opens a GitHub Issue with error details and recovery instructions. You can re-run the sync by commenting `\translate-resync` on the merged PR, or target a specific language with `\translate-resync fa`.
 
 Only changed sections are translated — the rest of the document is preserved exactly as-is.
 

--- a/src/__tests__/file-processor.test.ts
+++ b/src/__tests__/file-processor.test.ts
@@ -1,4 +1,7 @@
 import { Section } from '../types.js';
+import { FileProcessor } from '../file-processor.js';
+import { TranslationService } from '../translator.js';
+import { extractHeadingMap, extractTranslationTitle } from '../heading-map.js';
 
 /**
  * Tests for FileProcessor key methods
@@ -1239,5 +1242,186 @@ Market equilibrium occurs when supply equals demand.
       expect(merged[0].subsections[0].heading).toBe('#### 四级');
       expect(merged[0].subsections[0].subsections[0].heading).toBe('##### 五级');
     });
+  });
+});
+
+// ============================================================================
+// processFull — Heading-Map Injection
+// ============================================================================
+
+describe('FileProcessor.processFull — heading-map injection', () => {
+  let processor: FileProcessor;
+  let mockTranslator: jest.Mocked<TranslationService>;
+
+  beforeEach(() => {
+    mockTranslator = {
+      translateSection: jest.fn(),
+      translateFullDocument: jest.fn(),
+    } as any;
+    processor = new FileProcessor(mockTranslator, false);
+  });
+
+  it('should inject heading-map into translated new file with sections', async () => {
+    const sourceContent = `---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+---
+
+# Introduction
+
+Intro text.
+
+## Getting Started
+
+Content here.
+
+## Advanced Topics
+
+More content.
+`;
+
+    const translatedContent = `---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+---
+
+# 介绍
+
+介绍文字。
+
+## 入门指南
+
+内容在这里。
+
+## 高级主题
+
+更多内容。
+`;
+
+    mockTranslator.translateFullDocument.mockResolvedValue({
+      success: true,
+      translatedSection: translatedContent,
+    });
+
+    const result = await processor.processFull(
+      sourceContent,
+      'test.md',
+      'en',
+      'zh-cn',
+    );
+
+    // Should contain translation metadata
+    const headingMap = extractHeadingMap(result);
+    expect(headingMap.size).toBe(2);
+    expect(headingMap.get('Getting Started')).toBe('入门指南');
+    expect(headingMap.get('Advanced Topics')).toBe('高级主题');
+
+    // Should contain translated title
+    const title = extractTranslationTitle(result);
+    expect(title).toBe('介绍');
+  });
+
+  it('should handle title-only files (no sections) without error', async () => {
+    const sourceContent = `---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+---
+
+# Status
+
+This file has no sections.
+`;
+
+    const translatedContent = `---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+---
+
+# 状态
+
+这个文件没有章节。
+`;
+
+    mockTranslator.translateFullDocument.mockResolvedValue({
+      success: true,
+      translatedSection: translatedContent,
+    });
+
+    const result = await processor.processFull(
+      sourceContent,
+      'status.md',
+      'en',
+      'zh-cn',
+    );
+
+    // Title-only file: title should still be injected
+    const title = extractTranslationTitle(result);
+    expect(title).toBe('状态');
+
+    // No sections → no heading entries
+    const headingMap = extractHeadingMap(result);
+    expect(headingMap.size).toBe(0);
+  });
+
+  it('should handle subsections in heading-map', async () => {
+    const sourceContent = `---
+config: test
+---
+
+# Lecture
+
+Intro.
+
+## Main Section
+
+Content.
+
+### Subsection A
+
+Sub content.
+`;
+
+    const translatedContent = `---
+config: test
+---
+
+# 讲座
+
+简介。
+
+## 主要部分
+
+内容。
+
+### 子节 A
+
+子内容。
+`;
+
+    mockTranslator.translateFullDocument.mockResolvedValue({
+      success: true,
+      translatedSection: translatedContent,
+    });
+
+    const result = await processor.processFull(
+      sourceContent,
+      'lecture.md',
+      'en',
+      'zh-cn',
+    );
+
+    const headingMap = extractHeadingMap(result);
+    expect(headingMap.size).toBe(2);
+    expect(headingMap.get('Main Section')).toBe('主要部分');
+    // Subsection uses path-based key
+    expect(headingMap.get('Main Section::Subsection A')).toBe('子节 A');
   });
 });

--- a/src/cli/__tests__/status.test.ts
+++ b/src/cli/__tests__/status.test.ts
@@ -356,6 +356,52 @@ describe('checkFileStatus', () => {
     expect(result.flags).toContain('NOT_FOUND');
     expect(result.details).toContain('not found in either repo');
   });
+
+  it('should NOT flag MISSING_HEADINGMAP for title-only files (no ## sections)', async () => {
+    const sourceDir = path.join(tmpDir, 'source', 'lectures');
+    const targetDir = path.join(tmpDir, 'target', 'lectures');
+
+    // Title-only source (no ## headings)
+    const titleOnlySource = `---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+---
+
+# Status
+
+This file has only a title, no sections.
+`;
+
+    // Title-only target (no ## headings, no heading-map needed)
+    const titleOnlyTarget = `---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+---
+
+# 状态
+
+这个文件只有标题，没有章节。
+`;
+
+    writeMd(path.join(sourceDir, 'status.md'), titleOnlySource);
+    writeMd(path.join(targetDir, 'status.md'), titleOnlyTarget);
+
+    const result = await checkFileStatus(
+      'status.md',
+      path.join(tmpDir, 'source'),
+      path.join(tmpDir, 'target'),
+      'lectures',
+    );
+
+    expect(result.status).toBe('ALIGNED');
+    expect(result.flags).not.toContain('MISSING_HEADINGMAP');
+    expect(result.sourceSections).toBe(0);
+    expect(result.targetSections).toBe(0);
+  });
 });
 
 // ============================================================================

--- a/src/cli/commands/headingmap.ts
+++ b/src/cli/commands/headingmap.ts
@@ -19,8 +19,9 @@ import {
   extractHeadingMap,
   extractTranslationTitle,
   injectHeadingMap,
-  PATH_SEPARATOR,
+  buildHeadingMap,
 } from '../../heading-map.js';
+export { buildHeadingMap } from '../../heading-map.js';
 import { discoverMarkdownFiles, resolveFilePairs, applyExcludes } from './status.js';
 import { readFileState, writeFileState } from '../translate-state.js';
 
@@ -65,63 +66,6 @@ export interface HeadingmapResult {
 // ============================================================================
 // HEADING-MAP GENERATION
 // ============================================================================
-
-/**
- * Clean heading text by removing ## markers and stripping MyST inline roles.
- */
-function cleanHeading(heading: string): string {
-  return MystParser.stripMystRoles(heading.replace(/^#+\s+/, '').trim());
-}
-
-/**
- * Build a heading-map from matched source and target sections.
- * Uses position-based matching (same as section-matcher.ts).
- * Handles subsections recursively with path-based keys.
- */
-export function buildHeadingMap(
-  sourceSections: Section[],
-  targetSections: Section[],
-): { map: HeadingMap; warnings: string[] } {
-  const map: HeadingMap = new Map();
-  const warnings: string[] = [];
-
-  function processLevel(
-    sourceSecs: Section[],
-    targetSecs: Section[],
-    parentPath: string,
-  ): void {
-    const maxLen = Math.max(sourceSecs.length, targetSecs.length);
-
-    for (let i = 0; i < maxLen; i++) {
-      const source = i < sourceSecs.length ? sourceSecs[i] : null;
-      const target = i < targetSecs.length ? targetSecs[i] : null;
-
-      if (source && target) {
-        const sourceText = cleanHeading(source.heading);
-        const targetText = cleanHeading(target.heading);
-        const key = parentPath
-          ? `${parentPath}${PATH_SEPARATOR}${sourceText}`
-          : sourceText;
-
-        map.set(key, targetText);
-
-        // Recurse into subsections
-        if (source.subsections.length > 0 || target.subsections.length > 0) {
-          processLevel(source.subsections, target.subsections, key);
-        }
-      } else if (source && !target) {
-        const sourceText = cleanHeading(source.heading);
-        warnings.push(`SOURCE_ONLY: "${sourceText}" (position ${i + 1}) has no matching target section`);
-      } else if (!source && target) {
-        const targetText = cleanHeading(target.heading);
-        warnings.push(`TARGET_ONLY: "${targetText}" (position ${i + 1}) has no matching source section`);
-      }
-    }
-  }
-
-  processLevel(sourceSections, targetSections, '');
-  return { map, warnings };
-}
 
 /**
  * Generate or update heading-map for a single file pair.

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -203,9 +203,9 @@ export async function checkFileStatus(
     details.push(`${targetSectionCount} target vs ${sourceSectionCount} source sections`);
   }
 
-  // Check heading-map
+  // Check heading-map (only flag if the document actually has sections to map)
   const headingMap = extractHeadingMap(targetContent);
-  if (headingMap.size === 0) {
+  if (headingMap.size === 0 && sourceSectionCount > 0) {
     flags.push('MISSING_HEADINGMAP');
   }
 

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -22,9 +22,9 @@ import {
   updateHeadingMap, 
   lookupTargetHeading,
   injectHeadingMap,
+  buildHeadingMap,
   HeadingMap
 } from './heading-map.js';
-import { buildHeadingMap } from './cli/commands/headingmap.js';
 
 export class FileProcessor {
   private parser: MystParser;
@@ -517,21 +517,28 @@ export class FileProcessor {
 
     const translatedContent = result.translatedSection || '';
 
-    // Build heading-map from source and translated sections
-    const sourceParsed = await this.parser.parseDocumentComponents(content, filepath);
-    const translatedParsed = await this.parser.parseDocumentComponents(translatedContent, filepath);
+    // Build heading-map from source and translated sections.
+    // Wrapped in try/catch so a malformed translation (e.g. missing # title)
+    // doesn't fail the entire sync — we fall back to the raw translated content.
+    try {
+      const sourceParsed = await this.parser.parseDocumentComponents(content, filepath);
+      const translatedParsed = await this.parser.parseDocumentComponents(translatedContent, filepath);
 
-    const { map: headingMap } = buildHeadingMap(
-      sourceParsed.sections,
-      translatedParsed.sections,
-    );
+      const { map: headingMap } = buildHeadingMap(
+        sourceParsed.sections,
+        translatedParsed.sections,
+      );
 
-    const translatedTitle = translatedParsed.titleText || '';
+      const translatedTitle = translatedParsed.titleText || '';
 
-    // Inject heading-map into translated content
-    if (headingMap.size > 0 || translatedTitle) {
-      this.log(`Injecting heading-map with ${headingMap.size} entries and title "${translatedTitle}"`);
-      return injectHeadingMap(translatedContent, headingMap, translatedTitle);
+      // Inject heading-map into translated content
+      if (headingMap.size > 0 || translatedTitle) {
+        this.log(`Injecting heading-map with ${headingMap.size} entries and title "${translatedTitle}"`);
+        return injectHeadingMap(translatedContent, headingMap, translatedTitle);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      core.warning(`Failed to build heading-map for ${filepath}: ${msg}. Returning translated content without heading-map.`);
     }
 
     return translatedContent;

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -24,6 +24,7 @@ import {
   injectHeadingMap,
   HeadingMap
 } from './heading-map.js';
+import { buildHeadingMap } from './cli/commands/headingmap.js';
 
 export class FileProcessor {
   private parser: MystParser;
@@ -514,7 +515,26 @@ export class FileProcessor {
       throw new Error(`Full translation failed: ${result.error}`);
     }
 
-    return result.translatedSection || '';
+    const translatedContent = result.translatedSection || '';
+
+    // Build heading-map from source and translated sections
+    const sourceParsed = await this.parser.parseDocumentComponents(content, filepath);
+    const translatedParsed = await this.parser.parseDocumentComponents(translatedContent, filepath);
+
+    const { map: headingMap } = buildHeadingMap(
+      sourceParsed.sections,
+      translatedParsed.sections,
+    );
+
+    const translatedTitle = translatedParsed.titleText || '';
+
+    // Inject heading-map into translated content
+    if (headingMap.size > 0 || translatedTitle) {
+      this.log(`Injecting heading-map with ${headingMap.size} entries and title "${translatedTitle}"`);
+      return injectHeadingMap(translatedContent, headingMap, translatedTitle);
+    }
+
+    return translatedContent;
   }
 
   /**

--- a/src/heading-map.ts
+++ b/src/heading-map.ts
@@ -337,3 +337,57 @@ export function injectHeadingMap(
     return content;
   }
 }
+
+/**
+ * Build a heading-map from matched source and target sections.
+ * Uses position-based matching (same as section-matcher.ts).
+ * Handles subsections recursively with path-based keys.
+ */
+export function buildHeadingMap(
+  sourceSections: Section[],
+  targetSections: Section[],
+): { map: HeadingMap; warnings: string[] } {
+  const map: HeadingMap = new Map();
+  const warnings: string[] = [];
+
+  const cleanHeading = (heading: string): string => {
+    return MystParser.stripMystRoles(heading.replace(/^#+\s+/, '').trim());
+  };
+
+  function processLevel(
+    sourceSecs: Section[],
+    targetSecs: Section[],
+    parentPath: string,
+  ): void {
+    const maxLen = Math.max(sourceSecs.length, targetSecs.length);
+
+    for (let i = 0; i < maxLen; i++) {
+      const source = i < sourceSecs.length ? sourceSecs[i] : null;
+      const target = i < targetSecs.length ? targetSecs[i] : null;
+
+      if (source && target) {
+        const sourceText = cleanHeading(source.heading);
+        const targetText = cleanHeading(target.heading);
+        const key = parentPath
+          ? `${parentPath}${PATH_SEPARATOR}${sourceText}`
+          : sourceText;
+
+        map.set(key, targetText);
+
+        // Recurse into subsections
+        if (source.subsections.length > 0 || target.subsections.length > 0) {
+          processLevel(source.subsections, target.subsections, key);
+        }
+      } else if (source && !target) {
+        const sourceText = cleanHeading(source.heading);
+        warnings.push(`SOURCE_ONLY: "${sourceText}" (position ${i + 1}) has no matching target section`);
+      } else if (!source && target) {
+        const targetText = cleanHeading(target.heading);
+        warnings.push(`TARGET_ONLY: "${targetText}" (position ${i + 1}) has no matching source section`);
+      }
+    }
+  }
+
+  processLevel(sourceSections, targetSections, '');
+  return { map, warnings };
+}


### PR DESCRIPTION
## Summary

Two bugs discovered during Farsi sync diagnostics:

### Bug 1: New files translated via `processFull` missing heading-maps

When a new file is translated through the sync pipeline, `processFull()` returned the raw translated text without injecting a `translation:` frontmatter block. Only section-based updates (`processSectionBased`) correctly built and injected heading-maps.

**Fix**: After translation, `processFull` now parses both source and translated content into sections, calls `buildHeadingMap()` to position-match headings, and injects the `translation:` block via `injectHeadingMap()`.

### Bug 2: `MISSING_HEADINGMAP` false positive for title-only files

The `translate status` command flagged `MISSING_HEADINGMAP` for files with no `##` sections (e.g., `intro.md`, `status.md`). These files have only a `# Title` and body text — there are no sections to map, so an empty heading-map is expected.

**Fix**: Only flag `MISSING_HEADINGMAP` when `sourceSectionCount > 0`.

## Changes

| File | Change |
|---|---|
| `src/file-processor.ts` | `processFull()` now builds and injects heading-map after translation |
| `src/cli/commands/status.ts` | `MISSING_HEADINGMAP` only flagged when source has sections |
| `src/__tests__/file-processor.test.ts` | 3 new tests for `processFull` heading-map injection |
| `src/cli/__tests__/status.test.ts` | 1 new test for title-only file (no false positive) |

## Tests

976 pass (39 suites) — 4 new tests added.
## Summary

Fixes #58 — support an optional language suffix on `\translate-resync` so only the targeted workflow runs.

## Changes

**`src/inputs.ts`**
- Added `resyncLanguage?: string` to `PREventResult`
- `validateResyncComment` now splits the comment body and extracts the first word after `\translate-resync` as the language target (lowercased)
- Log message distinguishes targeted vs. all-language resync

**`src/index.ts`**
- `runSync` destructures `resyncLanguage` from the event result
- If `resyncLanguage` is set and doesn't match `inputs.targetLanguage`, the workflow exits early with a clear log message

**`src/__tests__/inputs.test.ts`**
- Added 4 new tests: `fa` target, `zh-cn` target, case normalization, bare `\translate-resync` returns `undefined`
- Updated existing trailing-text test to verify `resyncLanguage` is parsed

## Behavior

| Comment | Effect |
|---------|--------|
| `\translate-resync` | Retriggers all language workflows (backward compatible) |
| `\translate-resync fa` | Only the Farsi workflow runs; others exit early |
| `\translate-resync zh-cn` | Only the zh-cn workflow runs; others exit early |
