### PR TITLE
docs: publish/take-down passthrough for temporary experiment pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,22 @@ jobs:
         run: myst build --html
         working-directory: docs
 
+      # Static passthrough for temporary experiment pages (e.g. blind review
+      # packets). Anything under docs/_experiments/ is copied verbatim into the
+      # site at /experiments/... . MyST ignores the underscore-prefixed dir, so
+      # these self-contained HTML files are served as-is. No-op when absent —
+      # take an experiment down by deleting its folder under docs/_experiments/.
+      - name: Publish experiment pages (static passthrough)
+        run: |
+          if [ -d docs/_experiments ]; then
+            mkdir -p docs/_build/html/experiments
+            cp -R docs/_experiments/. docs/_build/html/experiments/
+            echo "Published experiment pages under /experiments/:"
+            find docs/_build/html/experiments -type f | sed 's#docs/_build/html/##'
+          else
+            echo "No docs/_experiments/ — nothing to publish."
+          fi
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,19 +46,25 @@ jobs:
         working-directory: docs
 
       # Static passthrough for temporary experiment pages (e.g. blind review
-      # packets). Anything under docs/_experiments/ is copied verbatim into the
-      # site at /experiments/... . MyST ignores the underscore-prefixed dir, so
-      # these self-contained HTML files are served as-is. No-op when absent —
-      # take an experiment down by deleting its folder under docs/_experiments/.
+      # packets). Each experiment SUBFOLDER of docs/_experiments/ is copied
+      # verbatim into the site at /experiments/<name>/ . MyST ignores the
+      # underscore-prefixed dir, so self-contained HTML is served as-is. Only
+      # subfolders are published — README.md and other stray files are not — and
+      # the step no-ops when there are no experiment subfolders. Take an
+      # experiment down by deleting its folder under docs/_experiments/.
       - name: Publish experiment pages (static passthrough)
         run: |
-          if [ -d docs/_experiments ]; then
-            mkdir -p docs/_build/html/experiments
-            cp -R docs/_experiments/. docs/_build/html/experiments/
-            echo "Published experiment pages under /experiments/:"
-            find docs/_build/html/experiments -type f | sed 's#docs/_build/html/##'
+          shopt -s nullglob
+          dirs=(docs/_experiments/*/)
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "No experiment folders under docs/_experiments/ — nothing to publish."
           else
-            echo "No docs/_experiments/ — nothing to publish."
+            for d in "${dirs[@]}"; do
+              name=$(basename "$d")
+              mkdir -p "docs/_build/html/experiments/$name"
+              cp -R "$d." "docs/_build/html/experiments/$name/"
+              echo "Published /experiments/$name/"
+            done
           fi
 
       - name: Upload artifact

--- a/docs/_experiments/README.md
+++ b/docs/_experiments/README.md
@@ -3,7 +3,9 @@
 Static passthrough for **temporary** experiment pages (e.g. blind translation
 review packets) that we want to host on the docs site for a while and then take
 down. The underscore prefix keeps MyST from processing this folder; the
-`deploy-docs` workflow copies it verbatim into the built site.
+`deploy-docs` workflow copies each **subfolder** here into the built site (this
+README and other top-level files are *not* published — only subfolders are, and
+the step no-ops when there are none).
 
 - **Served at:** `https://quantecon.github.io/action-translation/experiments/<...>`
   (a folder here → `/experiments/<folder>/`). Put an `index.html` in each folder.

--- a/docs/_experiments/README.md
+++ b/docs/_experiments/README.md
@@ -1,0 +1,38 @@
+# docs/_experiments — temporary experiment pages
+
+Static passthrough for **temporary** experiment pages (e.g. blind translation
+review packets) that we want to host on the docs site for a while and then take
+down. The underscore prefix keeps MyST from processing this folder; the
+`deploy-docs` workflow copies it verbatim into the built site.
+
+- **Served at:** `https://quantecon.github.io/action-translation/experiments/<...>`
+  (a folder here → `/experiments/<folder>/`). Put an `index.html` in each folder.
+- **Files are served as-is.** Use self-contained HTML (inline CSS/JS, no external
+  assets) so pages work regardless of the site's base URL.
+
+## Publish
+
+Drop a self-contained page/folder here and push to `main` (any change under
+`docs/**` triggers the deploy):
+
+```
+node experiments/thinking-sonnet5/scripts/make-review-packets.mjs --out docs/_experiments/thinking-sonnet5
+git add docs/_experiments/thinking-sonnet5 && git commit -m "publish thinking-eval review packets" && git push
+```
+
+→ live at `/experiments/thinking-sonnet5/`.
+
+## Take down (when the experiment is finished)
+
+```
+git rm -r docs/_experiments/thinking-sonnet5 && git commit -m "take down thinking-eval review packets" && git push
+```
+
+The next deploy serves the site without it.
+
+## ⚠️ Never put secrets here
+
+Everything in this folder is **published publicly**. Un-blinding keys, API keys,
+tokens, or anything private must stay out — e.g. the review packet generator
+writes its `id→variant` key to a private, git-ignored path and refuses to write
+it under `docs/`.


### PR DESCRIPTION
Sets up an **experiments section** on the docs site that we can publish and then take down — for hosting the blind translation-review packets (and future experiment artifacts) for reviewers like Emile.

## Why
Your docs deploy via `myst build` → a **single GitHub Pages Actions artifact** (`deploy-docs.yml`), not a `gh-pages` branch — so there's only one Pages deployment and experiment pages have to ride along in it (a separate `npx gh-pages`/second workflow would conflict with the docs deploy).

## What
- **`deploy-docs.yml`**: after the MyST build, a step copies `docs/_experiments/` verbatim into the site at `/experiments/…`. **No-op when the folder is absent.** The underscore prefix keeps MyST from processing it, so self-contained HTML is served as-is. (Validated: YAML parses; the copy maps `docs/_experiments/<x>/` → `/experiments/<x>/`.)
- **`docs/_experiments/README.md`**: documents the publish/take-down flow and the no-secrets rule.

## Publish / take-down
```
# publish (packets generated by the thinking-eval harness; key stays private):
node experiments/thinking-sonnet5/scripts/make-review-packets.mjs --out docs/_experiments/thinking-sonnet5
git add docs/_experiments/thinking-sonnet5 && git commit && git push        # → /experiments/thinking-sonnet5/
# take down when finished:
git rm -r docs/_experiments/thinking-sonnet5 && git commit && git push
```
Served at `https://quantecon.github.io/action-translation/experiments/thinking-sonnet5/`.

## Safety
Everything under `docs/_experiments/` is public. The review-packet generator writes its `id→variant` un-blinding key to a private, git-ignored path and **refuses to write it under `docs/`**, so blinding can't leak into the published site.

Only touches the docs-deploy workflow + a new README — no app/CLI changes. Merge at your discretion; the passthrough is inert until a folder is dropped under `docs/_experiments/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)