### PR TITLE
fix(fr): apply French typography deterministically instead of asking the model

### DIFF
--- a/scripts/typography/apply.mjs
+++ b/scripts/typography/apply.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Apply the deterministic typography rules to an ALREADY-translated repo.
+ *
+ * `translate init` now applies typography as part of translation, so fresh
+ * seeds need nothing. This is the repair path, for two cases:
+ *   - a repo seeded before the rule existed (the fr programming seed), and
+ *   - a typography rule that changes later and must be back-applied.
+ *
+ * It typesets the body AND the `translation.headings` / `translation.title`
+ * values in frontmatter. Both matter: init derives the heading map from the
+ * already-typeset text, so a repair that fixed only the body would leave the map
+ * describing headings that no longer match it.
+ *
+ * The transform is idempotent and only ever changes whitespace before the
+ * target language's high punctuation, so re-running it is safe.
+ *
+ * Prereq: `npm run build:cli`.
+ *
+ * Usage:
+ *   node scripts/typography/apply.mjs --repo ~/work/quantecon/lecture-python-programming.fr --lang fr
+ *   node scripts/typography/apply.mjs --repo <path> --lang fr --dry-run
+ *
+ * Flags: --repo --lang --docs-folder --dry-run
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
+import { applyTypography, hasTypographyRules } from '../../dist/typography.js';
+import { extractHeadingMap, extractTranslationTitle, injectHeadingMap } from '../../dist/heading-map.js';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--') ? process.argv[i + 1] : d; };
+const has = (n) => process.argv.includes(`--${n}`);
+
+const repo = arg('repo') ? path.resolve(arg('repo')) : null;
+const lang = arg('lang');
+const folder = arg('docs-folder', 'lectures');
+const dryRun = has('dry-run');
+
+if (!repo || !lang) { console.error('Usage: --repo <path> --lang <code> [--docs-folder lectures] [--dry-run]'); process.exit(1); }
+if (!fs.existsSync(repo)) { console.error(`Repo not found: ${repo}`); process.exit(1); }
+if (!hasTypographyRules(lang)) { console.error(`No typography rules for '${lang}' — nothing to do.`); process.exit(1); }
+
+const dir = path.join(repo, folder);
+if (!fs.existsSync(dir)) { console.error(`No ${folder}/ in ${repo}`); process.exit(1); }
+
+/**
+ * Prove we only ever touched spacing before high punctuation.
+ *
+ * `\\_` is js-yaml's escape for U+00A0 in a double-quoted scalar, so a typeset
+ * heading map serialises as "\u2026LLM\\_?". That parses straight back to a
+ * non-breaking space (verified against extractHeadingMap), so for comparison it
+ * counts as one \u2014 otherwise this check would flag every file whose frontmatter
+ * it had correctly updated.
+ */
+const normalize = (s) => s.replace(/\\_/g, ' ').replace(/[ \u00A0\u202F\t]*([;:!?])/g, '$1');
+
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/;
+const stripFrontmatter = (s) => { const m = s.match(FRONTMATTER); return m ? s.slice(m[0].length) : s; };
+const parseFrontmatter = (s) => {
+  const m = s.match(FRONTMATTER);
+  if (!m) return null;
+  try { return yaml.load(m[1]); } catch { return undefined; } // undefined ≠ null → mismatch → fails loudly
+};
+
+/** Deep equality over parsed YAML, with every string normalized. */
+function deepEqualNormalized(a, b) {
+  if (typeof a === 'string' && typeof b === 'string') return normalize(a) === normalize(b);
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  const ka = Object.keys(a), kb = Object.keys(b);
+  if (ka.length !== kb.length) return false;
+  return ka.every((k) => kb.includes(k) && deepEqualNormalized(a[k], b[k]));
+}
+
+const files = fs.readdirSync(dir).filter((f) => f.endsWith('.md')).sort();
+console.log(`${dryRun ? 'DRY RUN — ' : ''}typography (${lang}) over ${files.length} file(s) in ${path.relative(ROOT, dir) || dir}\n`);
+
+let changed = 0, failed = 0;
+for (const f of files) {
+  const p = path.join(dir, f);
+  const src = fs.readFileSync(p, 'utf-8');
+
+  // 1. Body (frontmatter is skipped by applyTypography).
+  let out = applyTypography(src, lang);
+
+  // 2. Frontmatter heading map + title, so they match the body they describe.
+  const map = extractHeadingMap(src);
+  const title = extractTranslationTitle(src);
+  if (map.size > 0 || title) {
+    const typesetMap = new Map([...map].map(([en, target]) => [en, applyTypography(target, lang)]));
+    const typesetTitle = title ? applyTypography(title, lang) : undefined;
+    out = injectHeadingMap(out, typesetMap, typesetTitle);
+  }
+
+  // 3. Safety net: nothing but spacing before high punctuation may differ.
+  //
+  // Body and frontmatter are checked differently on purpose. The body is
+  // compared as text, because that is where corruption would actually hurt.
+  // Frontmatter is compared as PARSED YAML, because re-serialising it
+  // legitimately changes quoting (js-yaml quotes a scalar once it contains a
+  // non-breaking space) — a textual diff there is noise, not a defect.
+  if (normalize(stripFrontmatter(src)) !== normalize(stripFrontmatter(out))) {
+    console.error(`  ✗ ${f} — body changed beyond spacing; NOT written`);
+    failed++;
+    continue;
+  }
+  if (!deepEqualNormalized(parseFrontmatter(src), parseFrontmatter(out))) {
+    console.error(`  ✗ ${f} — frontmatter changed beyond spacing; NOT written`);
+    failed++;
+    continue;
+  }
+  if (applyTypography(out, lang) !== out) {
+    console.error(`  ✗ ${f} — not idempotent; NOT written`);
+    failed++;
+    continue;
+  }
+
+  if (out === src) { console.log(`  · ${f} — already correct`); continue; }
+  const added = (out.match(/\u00A0/g) || []).length - (src.match(/\u00A0/g) || []).length;
+  console.log(`  ✓ ${f} — ${added} non-breaking space(s)`);
+  if (!dryRun) fs.writeFileSync(p, out, 'utf-8');
+  changed++;
+}
+
+console.log(`\n${dryRun ? 'Would change' : 'Changed'}: ${changed}/${files.length}${failed ? ` · FAILED: ${failed}` : ''}`);
+if (failed) process.exit(1);

--- a/src/__tests__/typography.test.ts
+++ b/src/__tests__/typography.test.ts
@@ -1,4 +1,4 @@
-import { applyTypography, hasTypographyRules } from '../typography';
+import { applyTypography, hasTypographyRules } from '../typography.js';
 
 const NBSP = '\u00A0';
 
@@ -43,6 +43,46 @@ describe('applyTypography', () => {
     it('applies before a closing delimiter', () => {
       expect(applyTypography('(Bonjour !)', 'fr')).toBe(`(Bonjour${NBSP}!)`);
     });
+
+    // A run must be spaced once, in front of the group — never split by putting
+    // the space between the marks, which corrupts the author's punctuation.
+    describe('consecutive high-punctuation runs', () => {
+      it.each([
+        ['Quoi?!', `Quoi${NBSP}?!`],
+        ['Quoi ?!', `Quoi${NBSP}?!`],
+        ['Non!!', `Non${NBSP}!!`],
+        ['Hein !?', `Hein${NBSP}!?`],
+        ['Vraiment ?!?', `Vraiment${NBSP}?!?`],
+      ])('spaces %p as a group', (src, expected) => {
+        expect(applyTypography(src, 'fr')).toBe(expected);
+      });
+
+      it('never inserts a space inside a run', () => {
+        const out = applyTypography('Quoi?! Et alors!!', 'fr');
+        expect(out).not.toContain(`?${NBSP}!`);
+        expect(out).not.toContain(`!${NBSP}!`);
+        expect(out).toBe(`Quoi${NBSP}?! Et alors${NBSP}!!`);
+      });
+
+      it('is idempotent over runs', () => {
+        const once = applyTypography('Quoi?! Non!!', 'fr');
+        expect(applyTypography(once, 'fr')).toBe(once);
+      });
+    });
+  });
+
+  describe('language lookup is not prototype-polluted', () => {
+    // `language` comes from user input (--target-language). An object lookup
+    // would resolve Object.prototype.toString and call it as a rule, replacing
+    // the document with "[object Undefined]".
+    it.each(['toString', 'constructor', 'hasOwnProperty', '__proto__', 'valueOf'])(
+      'treats %p as an unknown language and returns content unchanged',
+      (lang) => {
+        const src = 'Bonjour! Ça va?';
+        expect(applyTypography(src, lang)).toBe(src);
+        expect(hasTypographyRules(lang)).toBe(false);
+      }
+    );
   });
 
   describe('does not corrupt non-prose', () => {

--- a/src/__tests__/typography.test.ts
+++ b/src/__tests__/typography.test.ts
@@ -1,0 +1,231 @@
+import { applyTypography, hasTypographyRules } from '../typography';
+
+const NBSP = '\u00A0';
+
+describe('applyTypography', () => {
+  describe('languages without rules', () => {
+    it('leaves content untouched', () => {
+      const src = 'Hello! Is this right? Yes: it is.';
+      expect(applyTypography(src, 'en')).toBe(src);
+      expect(applyTypography(src, 'zh-cn')).toBe(src);
+    });
+
+    it('reports which languages have rules', () => {
+      expect(hasTypographyRules('fr')).toBe(true);
+      expect(hasTypographyRules('en')).toBe(false);
+    });
+  });
+
+  describe('French high punctuation', () => {
+    it.each([
+      ['Bonjour !', `Bonjour${NBSP}!`],
+      ['Vraiment ?', `Vraiment${NBSP}?`],
+      ['Voici :', `Voici${NBSP}:`],
+      ['Un ; deux', `Un${NBSP}; deux`],
+    ])('inserts NBSP in %p', (src, expected) => {
+      expect(applyTypography(src, 'fr')).toBe(expected);
+    });
+
+    it('handles the no-space case', () => {
+      expect(applyTypography('Bonjour!', 'fr')).toBe(`Bonjour${NBSP}!`);
+    });
+
+    it('is idempotent', () => {
+      const once = applyTypography('Bonjour ! Ça va ?', 'fr');
+      expect(applyTypography(once, 'fr')).toBe(once);
+    });
+
+    it('leaves an existing narrow NBSP alone', () => {
+      const src = `Bonjour\u202F!`;
+      expect(applyTypography(src, 'fr')).toBe(src);
+    });
+
+    it('applies before a closing delimiter', () => {
+      expect(applyTypography('(Bonjour !)', 'fr')).toBe(`(Bonjour${NBSP}!)`);
+    });
+  });
+
+  describe('does not corrupt non-prose', () => {
+    it('leaves code fences alone', () => {
+      const src = ['Texte :', '', '```python', 'x = a if b else c  # a ? b : c', 'd = {"k": 1}', '```'].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('# a ? b : c');
+      expect(out).toContain('d = {"k": 1}');
+      expect(out).toContain(`Texte${NBSP}:`);
+    });
+
+    it('leaves MyST code-cell directives alone', () => {
+      const src = ['```{code-cell} ipython3', 'print("ratio: 3:1")', 'y = x if x > 0 else -x', '```'].join('\n');
+      expect(applyTypography(src, 'fr')).toBe(src);
+    });
+
+    it('leaves inline code alone', () => {
+      const src = 'Utilisez `dict(a=1) : valeur` ici !';
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('`dict(a=1) : valeur`');
+      expect(out).toContain(`ici${NBSP}!`);
+    });
+
+    it('leaves math alone', () => {
+      const src = 'Soit $\\{x : x > 0\\}$ et donc :\n\n$$\na : b\n$$';
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('$\\{x : x > 0\\}$');
+      expect(out).toContain('a : b');
+      expect(out).toContain(`donc${NBSP}:`);
+    });
+
+    it('leaves YAML frontmatter alone', () => {
+      const src = ['---', 'title: Introduction', 'kernelspec:', '  name: python3', '---', '', 'Bonjour !'].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('title: Introduction');
+      expect(out).toContain('kernelspec:');
+      expect(out).toContain(`Bonjour${NBSP}!`);
+    });
+
+    it('leaves URLs and links alone', () => {
+      const src = 'Voir [le site](https://example.com/a?b=1&c=2) et https://x.org/p?q=1 !';
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('(https://example.com/a?b=1&c=2)');
+      expect(out).toContain('https://x.org/p?q=1');
+      expect(out).toContain(`!`);
+      expect(out).not.toContain(`https${NBSP}:`);
+    });
+
+    it('leaves MyST anchors and directive options alone', () => {
+      const src = ['(sec:intro)=', '# Titre', '', '```{figure} a.png', ':width: 100px', ':name: fig:one', '```'].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('(sec:intro)=');
+      expect(out).toContain(':width: 100px');
+      expect(out).toContain(':name: fig:one');
+    });
+
+    it('leaves MyST roles alone', () => {
+      const src = 'Voir {doc}`intro <sec:intro>` maintenant !';
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('{doc}`intro <sec:intro>`');
+      expect(out).toContain(`maintenant${NBSP}!`);
+    });
+
+    it('leaves HTML entities alone', () => {
+      const src = 'Un &nbsp; espace et &#8212; un tiret !';
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('&nbsp;');
+      expect(out).toContain('&#8212;');
+      expect(out).not.toContain(`&nbsp${NBSP};`);
+    });
+
+    it('leaves images alone', () => {
+      const src = 'Regardez ![une image](a.png) !';
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('![une image](a.png)');
+    });
+
+    it('leaves times and ratios alone', () => {
+      const src = 'Le ratio 3:1 à 14:30 est correct !';
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('3:1');
+      expect(out).toContain('14:30');
+      expect(out).toContain(`correct${NBSP}!`);
+    });
+
+    it('handles ::: colon fences', () => {
+      // {note} is a prose directive, so its body IS typeset; a code fence
+      // nested inside it is not.
+      const src = [
+        ':::{note}',
+        'Regardez ceci :',
+        '',
+        '```python',
+        'x = a if b else c  # a ? b : c',
+        '```',
+        ':::',
+        '',
+        'Fini !',
+      ].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('x = a if b else c  # a ? b : c');
+      expect(out).toContain(`Regardez ceci${NBSP}:`);
+      expect(out).toContain(`Fini${NBSP}!`);
+    });
+
+    it('leaves a code directive in a ::: fence alone', () => {
+      const src = [':::{code-cell} python', 'x = a if b else c  # a ? b : c', ':::'].join('\n');
+      expect(applyTypography(src, 'fr')).toBe(src);
+    });
+  });
+
+  describe('MyST prose directives', () => {
+    it('typesets prose inside an admonition', () => {
+      const src = ['```{hint}', 'Vos indices sont les suivants :', '```'].join('\n');
+      expect(applyTypography(src, 'fr')).toContain(`suivants${NBSP}:`);
+    });
+
+    it.each(['note', 'warning', 'tip', 'exercise', 'solution', 'important'])(
+      'typesets prose inside {%s}',
+      (directive) => {
+        const src = ['```{' + directive + '}', 'Attention !', '```'].join('\n');
+        expect(applyTypography(src, 'fr')).toContain(`Attention${NBSP}!`);
+      }
+    );
+
+    it('leaves directive options alone but typesets the body', () => {
+      const src = ['```{exercise}', ':label: ex:one', '', 'Calculez ceci :', '```'].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain(':label: ex:one');
+      expect(out).toContain(`ceci${NBSP}:`);
+    });
+
+    it('does not touch code nested inside a prose directive', () => {
+      const src = [
+        '````{note}',
+        'Regardez ce code :',
+        '',
+        '```{code-cell} python',
+        'y = a if a > 0 else b  # positif ? oui',
+        '```',
+        '',
+        'Fini !',
+        '````',
+      ].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('y = a if a > 0 else b  # positif ? oui');
+      expect(out).toContain(`ce code${NBSP}:`);
+      expect(out).toContain(`Fini${NBSP}!`);
+    });
+
+    it('treats unknown directives as code', () => {
+      const src = ['```{some-future-thing}', 'a ? b : c', '```'].join('\n');
+      expect(applyTypography(src, 'fr')).toBe(src);
+    });
+  });
+
+  describe('realistic document', () => {
+    it('fixes prose without touching structure', () => {
+      const src = [
+        '---',
+        'title: Les fonctions',
+        '---',
+        '',
+        '(sec:fn)=',
+        '# Les fonctions',
+        '',
+        'Voici un exemple : une fonction simple. Compris ?',
+        '',
+        '```{code-cell} python',
+        'def f(x):',
+        '    return x if x > 0 else 0  # positif ? oui',
+        '```',
+        '',
+        'Notez bien : $f : X \\to Y$ est défini !',
+      ].join('\n');
+      const out = applyTypography(src, 'fr');
+
+      expect(out).toContain(`exemple${NBSP}: une fonction simple. Compris${NBSP}?`);
+      expect(out).toContain(`Notez bien${NBSP}: $f : X \\to Y$ est défini${NBSP}!`);
+      expect(out).toContain('    return x if x > 0 else 0  # positif ? oui');
+      expect(out).toContain('title: Les fonctions');
+      expect(out).toContain('(sec:fn)=');
+      expect(out).toContain('def f(x):');
+    });
+  });
+});

--- a/src/__tests__/typography.test.ts
+++ b/src/__tests__/typography.test.ts
@@ -154,6 +154,54 @@ describe('applyTypography', () => {
     });
   });
 
+  describe('display math state tracking', () => {
+    // Regression: a $$ block opening with content on the same line was missed,
+    // so its closing $$ read as an opener and every later line in the file was
+    // treated as math. Observed in scipy.md — 2 real occurrences suppressed.
+    it('tracks a math block that opens with content on the same line', () => {
+      const src = [
+        'Par la loi des grands nombres,',
+        '',
+        '$$ \\mathbb E \\max\\{ S_n - K, 0 \\}',
+        '    \\approx',
+        '    \\frac{1}{M} \\sum_{m=1}^M \\max \\{S_n^m - K, 0 \\}',
+        '    $$',
+        '',
+        'Voici une solution :',
+      ].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain(`Voici une solution${NBSP}:`);
+      expect(out).toContain('$$ \\mathbb E \\max\\{ S_n - K, 0 \\}');
+    });
+
+    it('does not let $$ inside a code fence desync math state', () => {
+      const src = [
+        '```python',
+        'print("$$")',
+        '```',
+        '',
+        'Ensuite :',
+      ].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('print("$$")');
+      expect(out).toContain(`Ensuite${NBSP}:`);
+    });
+
+    it('handles self-contained $$ x $$ on one line', () => {
+      const src = ['$$ a : b $$', '', 'Donc :'].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('$$ a : b $$');
+      expect(out).toContain(`Donc${NBSP}:`);
+    });
+
+    it('recovers prose after a balanced math block', () => {
+      const src = ['$$', 'x : y', '$$', '', 'Fini !'].join('\n');
+      const out = applyTypography(src, 'fr');
+      expect(out).toContain('x : y');
+      expect(out).toContain(`Fini${NBSP}!`);
+    });
+  });
+
   describe('MyST prose directives', () => {
     it('typesets prose inside an admonition', () => {
       const src = ['```{hint}', 'Vos indices sont les suivants :', '```'].join('\n');

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -22,6 +22,7 @@ import { TranslationService } from '../../translator.js';
 import { MystParser } from '../../parser.js';
 import { Glossary } from '../../types.js';
 import { updateHeadingMap, injectHeadingMap } from '../../heading-map.js';
+import { applyTypography } from '../../typography.js';
 import { RuleId, buildLocalizationPrompt, getFontRequirements } from '../../localization-rules.js';
 import { readFileState, writeConfig, writeFileState } from '../translate-state.js';
 import { getFileGitMetadata } from '../git-metadata.js';
@@ -293,7 +294,9 @@ async function translateLecture(
     throw new Error(result.error || 'Translation failed');
   }
 
-  const translatedContent = result.translatedSection;
+  // Apply deterministic typography before anything derives from the text, so the
+  // heading map is built from the same strings that land in the body.
+  const translatedContent = applyTypography(result.translatedSection, options.targetLanguage);
 
   // Generate heading-map
   const { map: headingMap, title: translatedTitle } = await generateHeadingMap(sourceContent, translatedContent);

--- a/src/typography.ts
+++ b/src/typography.ts
@@ -1,0 +1,197 @@
+/**
+ * Deterministic typography post-processing for translated MyST Markdown.
+ *
+ * Some language rules are stated in the translation prompt and the model
+ * reliably ignores them anyway. French non-breaking spaces before high
+ * punctuation are the measured case: a real `python_by_example.md` translation
+ * came back with 0 × U+00A0, 0 × U+202F and 16 regular spaces before `; : ! ?`,
+ * despite the rule sitting in `language-config.ts`. Escalating the prompt is the
+ * wrong tool — this is a pure text transform with an exact specification, so we
+ * apply it deterministically and stop asking the model.
+ *
+ * The hard part is NOT the substitution, it is knowing where prose ends. Code
+ * (`a ? b : c`), math (`$\{x : x > 0\}$`), YAML frontmatter (`key: value`),
+ * MyST anchors (`(sec:intro)=`) and URLs (`https://`) all contain the same
+ * characters and must never be touched. Two independent defences:
+ *
+ *   1. classify every line as prose-eligible or not, then mask inline
+ *      constructs within the eligible ones, and
+ *   2. only substitute where the mark is followed by whitespace or end-of-line,
+ *      which alone rules out `sec:intro`, `14:30` and `![alt](x)`.
+ *
+ * Line classification is a stateful walk rather than a regex, because fences
+ * nest: a ```{code-cell} inside a ```` ```{note} ```` is code inside prose, and no
+ * single regex gets that right.
+ *
+ * Unknown directives are treated as CODE. Missing a non-breaking space is
+ * cosmetic; corrupting a code cell is a real bug, so the conservative default
+ * is to leave things alone.
+ */
+
+/**
+ * U+00A0. French typography also admits U+202F (narrow) before ; ! ?, but
+ * U+00A0 renders reliably in both HTML and PDF and matches the wording of the
+ * prompt rule in language-config.ts. Kept as one constant so a native reviewer
+ * can change the convention in one place.
+ */
+const NBSP = '\u00A0';
+
+/** Any existing non-breaking space counts as already-correct. */
+const EXISTING_NBSP = /[\u00A0\u202F]/;
+
+/**
+ * MyST directives whose body is prose to be typeset, not code. Anything not
+ * listed here is treated as code and left untouched.
+ */
+const PROSE_DIRECTIVES = new Set([
+  'admonition', 'attention', 'caution', 'danger', 'error', 'hint', 'important',
+  'note', 'seealso', 'tip', 'warning',
+  'exercise', 'exercise-start', 'exercise-end',
+  'solution', 'solution-start', 'solution-end',
+  'epigraph', 'margin', 'sidebar', 'topic', 'card', 'grid-item-card',
+  'proof', 'theorem', 'lemma', 'corollary', 'definition', 'remark', 'conjecture',
+]);
+
+const FENCE_OPEN = /^(\s{0,3})(`{3,}|~{3,}|:{3,})\s*(?:\{([\w:-]+)\})?/;
+const DIRECTIVE_OPTION = /^\s*:[a-zA-Z][\w-]*:/;
+const MATH_DELIM = /^\s*\$\$\s*$/;
+
+interface Fence {
+  marker: string;
+  prose: boolean;
+}
+
+/** Decide, line by line, which lines may carry prose typography. */
+function classifyLines(lines: string[]): boolean[] {
+  const eligible: boolean[] = new Array(lines.length).fill(false);
+  const stack: Fence[] = [];
+  let inFrontmatter = false;
+  let inMathBlock = false;
+  let awaitingOptions = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Leading YAML frontmatter — includes the translation heading map.
+    if (i === 0 && line.trim() === '---') { inFrontmatter = true; continue; }
+    if (inFrontmatter) {
+      if (line.trim() === '---') inFrontmatter = false;
+      continue;
+    }
+
+    // Display math block.
+    if (MATH_DELIM.test(line)) { inMathBlock = !inMathBlock; continue; }
+    if (inMathBlock) continue;
+
+    const top = stack[stack.length - 1];
+    const open = FENCE_OPEN.exec(line);
+
+    if (open) {
+      const [, , marker, directive] = open;
+      // A closing fence uses the same character, at least as long, and carries
+      // no directive name.
+      if (top && !directive && marker[0] === top.marker[0] && marker.length >= top.marker.length) {
+        stack.pop();
+        continue;
+      }
+      // Inside code, nothing opens — it is just code text.
+      if (top && !top.prose) continue;
+      const prose = Boolean(directive) && PROSE_DIRECTIVES.has(directive.toLowerCase());
+      stack.push({ marker, prose });
+      awaitingOptions = prose;
+      continue;
+    }
+
+    if (!top) { eligible[i] = true; continue; }
+    if (!top.prose) continue; // inside a code fence
+
+    // Directive options (`:name: fig-one`) sit directly under the opener.
+    if (awaitingOptions) {
+      if (DIRECTIVE_OPTION.test(line)) continue;
+      if (line.trim() === '') continue;
+      awaitingOptions = false;
+    }
+    eligible[i] = true;
+  }
+
+  return eligible;
+}
+
+/** Inline constructs that must survive untouched inside an otherwise-prose line. */
+const INLINE_PROTECTED: RegExp[] = [
+  /\$[^$\n]+\$/g, // inline math
+  /`[^`\n]+`/g, // inline code — also covers MyST roles: {doc}`intro <sec:intro>`
+  /!?\[[^\]]*\]\([^)]*\)/g, // links and images, including the URL
+  /<[^>\n]+>/g, // HTML tags and autolinks
+  /&(?:[a-zA-Z]+\d*|#\d+|#x[0-9a-fA-F]+);/g, // HTML entities — &nbsp; ends in ;
+  /https?:\/\/\S+/g, // bare URLs
+];
+
+const PLACEHOLDER = '\u0000';
+
+/**
+ * French: a non-breaking space before ; : ! ?
+ *
+ * Applied only where the mark is followed by whitespace, end-of-line, or a
+ * closing delimiter — i.e. terminal punctuation in prose, rather than a
+ * separator inside an identifier, ratio or time.
+ */
+function applyFrenchSpacing(text: string): string {
+  return text.replace(
+    /(\S)([ \t]*)([;:!?])(?=[\s)\]»"'.,]|$)/g,
+    (match, before: string, gap: string, punct: string) => {
+      if (EXISTING_NBSP.test(before)) return match; // already correct
+      if (before === '\\') return match; // escaped
+      if (before === punct) return match; // ?? !! :: — space the first only
+      if (gap.length === 0 && /\d/.test(before) && punct === ':') return match; // 14:30
+      return `${before}${NBSP}${punct}`;
+    }
+  );
+}
+
+function applyToProse(line: string, rule: (text: string) => string): string {
+  const chunks: string[] = [];
+  let masked = line;
+  for (const pattern of INLINE_PROTECTED) {
+    masked = masked.replace(pattern, (m) => {
+      chunks.push(m);
+      return `${PLACEHOLDER}${chunks.length - 1}${PLACEHOLDER}`;
+    });
+  }
+  // MyST anchors — a whole-line construct: (sec:intro)=
+  if (/^\s*\([^)\n]*\)=\s*$/.test(masked)) return line;
+
+  let out = rule(masked);
+  for (let i = 0; i < INLINE_PROTECTED.length + 1; i++) {
+    const next = out.replace(
+      new RegExp(`${PLACEHOLDER}(\\d+)${PLACEHOLDER}`, 'g'),
+      (_, idx) => chunks[Number(idx)] ?? ''
+    );
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+const RULES: Record<string, (text: string) => string> = {
+  fr: applyFrenchSpacing,
+};
+
+/**
+ * Apply deterministic typography rules for `language` to translated MyST
+ * content. A no-op for languages with no rules, and idempotent — running it
+ * twice produces the same result, so it is safe on already-processed files.
+ */
+export function applyTypography(content: string, language: string): string {
+  const rule = RULES[language];
+  if (!rule) return content;
+
+  const lines = content.split('\n');
+  const eligible = classifyLines(lines);
+  return lines.map((line, i) => (eligible[i] ? applyToProse(line, rule) : line)).join('\n');
+}
+
+/** Languages with a deterministic typography pass. */
+export function hasTypographyRules(language: string): boolean {
+  return language in RULES;
+}

--- a/src/typography.ts
+++ b/src/typography.ts
@@ -39,6 +39,9 @@ const NBSP = '\u00A0';
 /** Any existing non-breaking space counts as already-correct. */
 const EXISTING_NBSP = /[\u00A0\u202F]/;
 
+/** The French "high" punctuation this pass spaces. */
+const HIGH_PUNCTUATION = /[;:!?]/;
+
 /**
  * MyST directives whose body is prose to be typeset, not code. Anything not
  * listed here is treated as code and left untouched.
@@ -161,16 +164,25 @@ const PLACEHOLDER = '\u0000';
  * Applied only where the mark is followed by whitespace, end-of-line, or a
  * closing delimiter — i.e. terminal punctuation in prose, rather than a
  * separator inside an identifier, ratio or time.
+ *
+ * A run of high punctuation (`?!`, `!!`) is matched WHOLE and spaced once, in
+ * front of the group: `Quoi?!` → `Quoi ?!`. Matching a single mark instead
+ * splits the run — the space lands between the `?` and the `!` — which is both
+ * wrong typography and a corruption of the author's punctuation.
  */
 function applyFrenchSpacing(text: string): string {
   return text.replace(
-    /(\S)([ \t]*)([;:!?])(?=[\s)\]»"'.,]|$)/g,
-    (match, before: string, gap: string, punct: string) => {
+    /(\S)([ \t]*)([;:!?]+)(?=[\s)\]»"'.,]|$)/g,
+    (match, before: string, gap: string, run: string) => {
       if (EXISTING_NBSP.test(before)) return match; // already correct
       if (before === '\\') return match; // escaped
-      if (before === punct) return match; // ?? !! :: — space the first only
-      if (gap.length === 0 && /\d/.test(before) && punct === ':') return match; // 14:30
-      return `${before}${NBSP}${punct}`;
+      // `before` is itself high punctuation → we are inside an already-spaced
+      // run. On a second pass the NBSP counts as whitespace, so `\S` cannot
+      // anchor to it and scanning resumes mid-run: without this, `Quoi ?!`
+      // would become `Quoi ? !` and the transform would not be idempotent.
+      if (HIGH_PUNCTUATION.test(before)) return match;
+      if (gap.length === 0 && /\d/.test(before) && run === ':') return match; // 14:30
+      return `${before}${NBSP}${run}`;
     }
   );
 }
@@ -199,9 +211,15 @@ function applyToProse(line: string, rule: (text: string) => string): string {
   return out;
 }
 
-const RULES: Record<string, (text: string) => string> = {
-  fr: applyFrenchSpacing,
-};
+/**
+ * A Map, not a plain object: language codes come from user input
+ * (`--target-language`), and an object lookup resolves the prototype chain.
+ * `applyTypography(content, 'toString')` would otherwise find
+ * Object.prototype.toString, call it as a rule, and replace the whole document
+ * with "[object Undefined]". A Map has no such chain, so the lookup can only
+ * ever find a rule we actually registered.
+ */
+const RULES = new Map<string, (text: string) => string>([['fr', applyFrenchSpacing]]);
 
 /**
  * Apply deterministic typography rules for `language` to translated MyST
@@ -209,7 +227,7 @@ const RULES: Record<string, (text: string) => string> = {
  * twice produces the same result, so it is safe on already-processed files.
  */
 export function applyTypography(content: string, language: string): string {
-  const rule = RULES[language];
+  const rule = RULES.get(language);
   if (!rule) return content;
 
   const lines = content.split('\n');
@@ -219,5 +237,5 @@ export function applyTypography(content: string, language: string): string {
 
 /** Languages with a deterministic typography pass. */
 export function hasTypographyRules(language: string): boolean {
-  return language in RULES;
+  return RULES.has(language);
 }

--- a/src/typography.ts
+++ b/src/typography.ts
@@ -54,7 +54,19 @@ const PROSE_DIRECTIVES = new Set([
 
 const FENCE_OPEN = /^(\s{0,3})(`{3,}|~{3,}|:{3,})\s*(?:\{([\w:-]+)\})?/;
 const DIRECTIVE_OPTION = /^\s*:[a-zA-Z][\w-]*:/;
-const MATH_DELIM = /^\s*\$\$\s*$/;
+/**
+ * Display-math delimiters are counted, not matched whole-line. A block may open
+ * with content on the same line:
+ *
+ *     $$ \mathbb E \max\{ S_n - K, 0 \}
+ *         \approx ...
+ *         $$
+ *
+ * Matching only a bare `$$` line misses that opener and then reads the closer as
+ * an opener, leaving the parser convinced the rest of the file is math — which
+ * silently suppressed every substitution after it in scipy.md.
+ */
+const MATH_DELIM = /\$\$/g;
 
 interface Fence {
   marker: string;
@@ -79,12 +91,29 @@ function classifyLines(lines: string[]): boolean[] {
       continue;
     }
 
-    // Display math block.
-    if (MATH_DELIM.test(line)) { inMathBlock = !inMathBlock; continue; }
-    if (inMathBlock) continue;
-
     const top = stack[stack.length - 1];
     const open = FENCE_OPEN.exec(line);
+
+    // Inside a code fence, look only for its closer. This must come before the
+    // math check: a `$$` inside a code cell is code, and toggling math state on
+    // it would desync everything downstream.
+    if (top && !top.prose) {
+      if (open) {
+        const [, , marker, directive] = open;
+        if (!directive && marker[0] === top.marker[0] && marker.length >= top.marker.length) stack.pop();
+      }
+      continue;
+    }
+
+    // Display math. Toggle once per delimiter, so a block that opens with
+    // content on the same line is tracked correctly and a self-contained
+    // `$$ x $$` nets out to no state change. A line carrying any delimiter is
+    // math, never prose.
+    const delimiters = (line.match(MATH_DELIM) || []).length;
+    if (inMathBlock || delimiters > 0) {
+      if (delimiters % 2 === 1) inMathBlock = !inMathBlock;
+      continue;
+    }
 
     if (open) {
       const [, , marker, directive] = open;
@@ -94,8 +123,6 @@ function classifyLines(lines: string[]): boolean[] {
         stack.pop();
         continue;
       }
-      // Inside code, nothing opens — it is just code text.
-      if (top && !top.prose) continue;
       const prose = Boolean(directive) && PROSE_DIRECTIVES.has(directive.toLowerCase());
       stack.push({ marker, prose });
       awaitingOptions = prose;
@@ -103,7 +130,6 @@ function classifyLines(lines: string[]): boolean[] {
     }
 
     if (!top) { eligible[i] = true; continue; }
-    if (!top.prose) continue; // inside a code fence
 
     // Directive options (`:name: fig-one`) sit directly under the opener.
     if (awaitingOptions) {


### PR DESCRIPTION
Since French support landed, the prompt has instructed the model to put a non-breaking space before `; : ! ?` ([`language-config.ts:53`](https://github.com/QuantEcon/action-translation/blob/main/src/language-config.ts#L53)). It doesn't. Measured on a real Opus translation of `python_by_example.md`: **0 × U+00A0, 0 × U+202F, and 16 plain spaces** before high punctuation. Across the 26-lecture French seed that's ~199 occurrences of wrong typography in published lectures.

This is a pure text transform with an exact specification. Escalating the prompt is the wrong tool — the fix is to do it in code and stop asking the model.

## Where prose ends is the actual problem

The substitution is trivial. Knowing *where* to apply it is not: `a ? b : c` in a code cell, `$\{x : x > 0\}$` in math, `key: value` in frontmatter, `(sec:intro)=` anchors and `https://` URLs all contain the same characters and must never be touched.

Two independent defences, either of which would catch most cases:

1. **Classify every line** as prose-eligible or not, then mask inline constructs (math, code spans, links, entities) within the eligible ones.
2. **Only substitute where the mark is followed by whitespace or end-of-line** — which by itself rules out `sec:intro`, `14:30` and `![alt](x)`.

Line classification is a stateful walk rather than a regex, because fences nest: a ```{code-cell} inside a ```{note} is code inside prose, and no single regex gets that right.

The subtlety worth reviewing: **`{note}`, `{hint}`, `{exercise}` and `{solution}` bodies are prose** and must be typeset. An early regex version masked every fence as code and silently skipped them — that's how `Vos indices sont les suivants :` inside a `{hint}` survived a first pass looking correct. Unknown directives default to **code**: a missed space is cosmetic, a corrupted code cell is not.

## Hook point

`applyTypography` runs in `init` **before** `generateHeadingMap`, so the heading map is derived from the same strings that land in the body rather than drifting one character away from them.

One consequence a reviewer should see coming: js-yaml escapes U+00A0 as `\_` in double-quoted scalars, so frontmatter heading maps now serialise as `"Ne puis-je pas simplement utiliser des LLM\_?"`. That is valid YAML and round-trips back to U+00A0 — verified against the real `extractHeadingMap` — it just looks odd on first sight.

## Repair path

`scripts/typography/apply.mjs` back-applies the rules to a repo seeded before this existed (the French programming seed) or when a rule changes later. It refuses to write unless the only difference is spacing before high punctuation: the body is compared as text, the frontmatter as *parsed YAML*, because re-serialising legitimately changes quoting. That safety net earned its place — it caught the `\_` escape and the quoting change during development, both of which a naive byte-diff would have called corruption.

## Scope

**init only.** The sync path derives its heading map from translated sections before reconstruction, so wiring typography in there correctly needs the heading-map matching semantics pinned down first. I'd rather flag that than guess at it. Filed as follow-up.

`U+00A0` over `U+202F` (narrow) is deliberate: it renders reliably in both HTML and PDF and matches the existing prompt wording. It's a single constant, so a native reviewer can change the convention in one place — a reasonable question for Emile alongside the glossary round.

## Verification

- 34 unit tests covering each protected construct, prose directives, nested code inside prose, idempotence, and a realistic document.
- Full suite green (1040 tests).
- Checked over the 23 seeded French lectures: the **only** change is spacing before `; : ! ?`, and the transform is idempotent. The 37 untouched occurrences were audited — 19 are code (`z[0, :]`, `observations : array_like`, French prose inside `#` comments) and 18 are frontmatter heading-map values, which the repair script handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
