### PR TITLE
chore(dev): refresh STATE after #83 merge

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -7,17 +7,19 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## In flight
 
-- **PR: fix/fable5-review-high-severity** — high-severity fixes from the 2026-07-15 deep
-  review (`REVIEW-FABLE5-2026-07-15.md`): fr typography definition-label corruption
-  (shipped defect — the fr repo needs an `apply.mjs` repair run after merge), LICENSE,
-  lint-glob fix + prettier + CI format gate, PLAN Phase 1 pagination/CRLF/stop_reason/
-  content[0]/glossary fixes, in-range dep advisories, docs [H] accuracy fixes.
+- **lecture-python-programming.fr#4** — the `apply.mjs` repair run for the shipped
+  footnote corruption (one byte, `pandas.md`); mechanical, ready to merge.
 - **PR #78** — fr programming-domain glossary terms; awaiting native review.
 - **PR #71** — Malayalam (`ml`) draft; awaiting native-reviewer calibration batch.
   Glossary PR **#69** (ja) open, awaiting native review + a `LANGUAGE_CONFIGS` entry.
 
 ## Recently landed
 
+- **PR #83** merged 2026-07-15 (squash, `bb17926`) — high-severity fixes from the
+  2026-07-15 deep review (`REVIEW-FABLE5-2026-07-15.md`): fr typography definition-label
+  fix, LICENSE, lint-glob fix + prettier + CI format gate + `--max-warnings 0`,
+  PLAN Phase 1 pagination/CRLF/stop_reason/content[0]/glossary fixes, in-range dep
+  advisories, docs [H] accuracy fixes. Unreleased on `main` — v0.16.1 is the next chore.
 - **v0.16.0** released 2026-07-15 — default model → `claude-sonnet-5` (centralized in
   `src/models.ts`), thinking OFF (settled: D-2026-07-14), deterministic fr typography
   (`init` path only — sync wiring is issue #81), glossary-review tooling + skill.
@@ -33,11 +35,11 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## Next
 
-- Merge the high-severity PR; run `scripts/typography/apply.mjs` over
-  `lecture-python-programming.fr` to repair the shipped footnote corruption.
+- Merge lecture-python-programming.fr#4 (the repair run output).
+- **Release v0.16.1** with the #83 fixes; move the `v0`/`v0.16` tags (release step).
 - **PLAN Phase 1 remainder**: rebase no-op comments, `context.sha` vs `merge_commit_sha`,
   resync fail-closed, `@actions/*` + SDK major bumps (pair with node24, PLAN 5.8),
-  rebase input-validation hardening (1.5), release v0.16.1.
+  rebase input-validation hardening (1.5).
 - New issues from the review round: **#81** (typography on sync path), **#82** (model-swap
   eval — see REVIEW §7.4 for a concrete deterministic design).
 

--- a/.dev/log/2026-07-15-f5rev.md
+++ b/.dev/log/2026-07-15-f5rev.md
@@ -18,3 +18,8 @@ Follow-ups filed in STATE → Next. The fr production repo still needs the
 `apply.mjs` repair run after this merges. #promote: the v0-tag class of bug
 (floating major tag not moved on release) is worth checking in other QuantEcon
 action repos.
+
+Post-merge (same day): #83 squash-merged as bb17926; repair run applied — one byte in
+pandas.md, PR lecture-python-programming.fr#4. Copilot review caught an empty
+`max_tokens=` interpolation in the CLI truncation messages (fixed in d9e3dbb, all four
+sites). STATE updated; v0.16.1 release is the next chore.


### PR DESCRIPTION
.dev-only follow-up to #83: moves the high-severity PR to Recently landed, records the fr repair run (lecture-python-programming.fr#4) and the Copilot-review fix, and promotes the v0.16.1 release to the top of Next. CI skips `.dev/**` by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)