### PR TITLE
chore: release v0.16.1

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -36,7 +36,7 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 ## Next
 
 - Merge lecture-python-programming.fr#4 (the repair run output).
-- **Release v0.16.1** with the #83 fixes; move the `v0`/`v0.16` tags (release step).
+- **Release v0.16.1** — PR open (chore/release-v0.16.1); tag + move `v0`/`v0.16` after merge.
 - **PLAN Phase 1 remainder**: rebase no-op comments, `context.sha` vs `merge_commit_sha`,
   resync fail-closed, `@actions/*` + SDK major bumps (pair with node24, PLAN 5.8),
   rebase input-validation hardening (1.5).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -226,7 +226,14 @@ Before creating a release, verify the following:
 2. **Version bumped** — update `package.json`, this file (`copilot-instructions.md`), and `.dev/PLAN.md`
 3. **Tests pass** — run `npm test` and confirm all tests pass
 4. **Build succeeds** — run `npm run build` to compile TypeScript and update `dist-action/`
-5. **Commit, tag, push** — commit all changes, create git tag `vX.Y.Z`, push with `--tags`; **also move the floating tags** `vX.Y` and `v0` to the release commit (`git tag -f v0 vX.Y.Z && git push -f origin v0` etc.) — the README quickstart recommends `@v0`, and it went stale for 9 releases once
+5. **Commit, tag, push** — commit all changes, create git tag `vX.Y.Z`, push with `--tags`; **then move both floating tags** to the release commit:
+
+   ```bash
+   git tag -f vX.Y vX.Y.Z && git push -f origin vX.Y   # e.g. v0.16
+   git tag -f v0   vX.Y.Z && git push -f origin v0
+   ```
+
+   The README quickstart recommends `@v0`; it went stale for 9 releases once (stuck at v0.7.0-era code through v0.16.0).
 6. **Create GitHub release** — `gh release create vX.Y.Z --title "..." --notes-file .dev/scratch/release-notes.md`
 
 ---

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@
 - **Review Mode**: Runs in TARGET repo, posts quality review comments on translation PRs
 - **Rebase Mode**: Runs in TARGET repo, rebases conflicted translation PRs when a sibling PR is merged
 
-**Current Version**: v0.16.0 | **Tests**: 1056 (40 suites) | **Glossary**: 357 terms (zh-cn, fa, fr)
+**Current Version**: v0.16.1 | **Tests**: 1,000+ (40 suites; exact count in CI) | **Glossary**: 357 terms (zh-cn, fa, fr)
 
 ---
 
@@ -102,7 +102,7 @@ Title is stored explicitly; headings are flat (no nesting), include all heading 
 
 ### Running Tests
 ```bash
-npm test                          # All 1001 tests
+npm test                          # Full test suite
 npm test -- parser.test.ts        # Single file
 npm test -- --watch               # Watch mode
 npm test -- --coverage            # Coverage report
@@ -226,7 +226,7 @@ Before creating a release, verify the following:
 2. **Version bumped** — update `package.json`, this file (`copilot-instructions.md`), and `.dev/PLAN.md`
 3. **Tests pass** — run `npm test` and confirm all tests pass
 4. **Build succeeds** — run `npm run build` to compile TypeScript and update `dist-action/`
-5. **Commit, tag, push** — commit all changes, create git tag `vX.Y.Z`, push with `--tags`
+5. **Commit, tag, push** — commit all changes, create git tag `vX.Y.Z`, push with `--tags`; **also move the floating tags** `vX.Y` and `v0` to the release commit (`git tag -f v0 vX.Y.Z && git push -f origin v0` etc.) — the README quickstart recommends `@v0`, and it went stale for 9 releases once
 6. **Create GitHub release** — `gh release create vX.Y.Z --title "..." --notes-file .dev/scratch/release-notes.md`
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-15
+
 ### Fixed
 - **French typography no longer corrupts footnote/link-reference definitions**: the NBSP pass rewrote `[^id]: text` as `[^id] : text`, which stops the line parsing as a definition — it rendered as literal text and broke every reference (shipped in the fr seed, e.g. `pandas.md`). Definition labels are now masked, and the exact corruption is repaired on contact, so running `scripts/typography/apply.mjs` over an affected repo heals it. The definition text after the colon is still typeset.
 - **GitHub API pagination** at all five unpaginated call sites: sync `pulls.listFiles` (PRs touching >30 files were silently truncated), review mode's two `listFiles` calls, rebase's `pulls.list` (sibling PRs beyond 100), and `postReviewComment`'s `listComments` (the existing review comment was missed past 30 comments, accumulating duplicates).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-translation",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "action-translation",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",
@@ -38,6 +38,9 @@
         "prettier": "^3.1.0",
         "ts-jest": "^29.1.1",
         "typescript": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-translation",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "type": "module",
   "description": "GitHub Action to sync and review translations across repositories",


### PR DESCRIPTION
Promotes `[Unreleased]` → `[0.16.1] - 2026-07-15` (the #83 high-severity fixes), bumps `package.json`/lockfile/copilot-instructions to 0.16.1, rebuilds `dist-action/`, and adds the floating-tag move (`v0` / `vX.Y`) to the release checklist so the tag can't go stale again.

After merge I'll tag `v0.16.1`, move `v0` and `v0.16`, and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)