### PR TITLE
chore(harness): commit v0.16.1 baselines; fix reports/ being silently ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ docs/_build/
 .cache/
 
 # Generated reports (output of CLI tools)
-reports/
+/reports/
 
 # Test repositories (cloned locally for testing)
 test-translation-sync/

--- a/tool-test-action-on-github/reports/README.md
+++ b/tool-test-action-on-github/reports/README.md
@@ -53,3 +53,15 @@ Reports are automatically saved to this folder with the format `evaluation-YYYY-
 - **PASS** (✅): Overall ≥8, Diff ≥8
 - **WARN** (⚠️): Overall ≥6, Diff ≥6  
 - **FAIL** (❌): Below thresholds
+
+## Baselines
+
+| report | action model | judge | notes |
+|---|---|---|---|
+| `evaluation-2025-12-04/05.md` | Sonnet 4.5 | `claude-opus-4-5-20251101` | 24 pairs. Predates the v0.13.0 `translation:` frontmatter format. |
+| `evaluation-2026-07-15-sonnet5-v2.md` | **Sonnet 5** (v0.16.1) | `claude-opus-4-5-20251101` | 25 pairs. Judge pinned to the 2025-12 one so the comparison isolates the translation model. |
+| `evaluation-2026-07-15-sonnet5-opus48.md` | **Sonnet 5** (v0.16.1) | `claude-opus-4-8` | 26 pairs. Current-generation judge; absolute read, not comparable to the 2025-12 scores. |
+
+**Comparing against a baseline?** Pin the judge to the one that report used (`--model <its **Evaluator**: header>`). Moving the judge and the translation model together makes a score delta unattributable to either.
+
+**A denominator below the scenario count means the run was incomplete** — since 2026-07-15 the report says so explicitly; before that, dropped pairs vanished silently, so the "24 pairs" in the 2025-12 reports cannot be confirmed as 24 of 24.

--- a/tool-test-action-on-github/reports/evaluation-2026-07-15-sonnet5-opus48.md
+++ b/tool-test-action-on-github/reports/evaluation-2026-07-15-sonnet5-opus48.md
@@ -1,0 +1,336 @@
+# Translation Evaluation Report
+
+**Generated**: 2026-07-15T10:42:53.254Z
+**Evaluator**: claude-opus-4-8
+**Source Repository**: QuantEcon/test-translation-sync
+**Target Repository**: QuantEcon/test-translation-sync.zh-cn
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| PR Pairs Evaluated | 26 |
+| Passed ✅ | 23 |
+| Warnings ⚠️ | 2 |
+| Failed ❌ | 1 |
+| Avg Translation Score | 9.6/10 |
+| Avg Diff Score | 9.6/10 |
+
+---
+
+## Per-PR Results
+
+### ⚠️ Heading case change (title-case → sentence-case) (26 - lecture)
+
+- **Source PR**: [#670](https://github.com/QuantEcon/test-translation-sync/pull/670)
+- **Target PR**: [#635](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/635)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 7.5/10
+- **Verdict**: WARN
+
+**Translation Summary**: A high-quality, faithful translation with excellent formatting preservation and accurate mathematical content. The main terminology issue is the use of '里昂惕夫' instead of the glossary-specified '列昂惕夫' for Leontief. A few sentences could be smoothed for more natural Chinese phrasing, but overall the translation is accurate, fluent, and well-structured.
+
+**Diff Summary**: Scope, structure, and heading-map are correct, but the target contains an unrelated content edit in the eigenvalues section that has no corresponding source change.
+
+### ✅ Pre-title content (anchor + raw block) (25 - lecture)
+
+- **Source PR**: [#669](https://github.com/QuantEcon/test-translation-sync/pull/669)
+- **Target PR**: [#634](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/634)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: A high-quality, accurate, and fluent translation of the modified sections. Mathematical and code formatting is fully preserved. The main terminology concern is the use of '里昂惕夫逆矩阵' instead of the glossary-preferred '列昂惕夫逆矩阵' for the Leontief Inverse. Otherwise, the changed sections (preamble, Applications in Economics, Eigenvalues and Eigenvectors) read naturally and preserve the source meaning well.
+
+**Diff Summary**: The translation sync correctly mirrored the two English source changes (header injection with raw jupyter block/label and the {index} title role, plus the eigenvalue intro sentence expansion) into the Chinese target at the same positions, while properly migrating heading-map to the translation block.
+
+### ✅ Empty sections (heading only) (24 - minimal)
+
+- **Source PR**: [#668](https://github.com/QuantEcon/test-translation-sync/pull/668)
+- **Target PR**: [#633](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/633)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: An excellent, high-quality translation of the added economic theory framework sections. All technical terminology aligns with the reference glossary, the prose is fluent and appropriately academic, and MyST/Markdown formatting including the translation frontmatter block is fully intact. No accuracy, fluency, terminology, formatting, or syntax issues were found in the changed sections.
+
+**Diff Summary**: The translation sync correctly restructured the Chinese document to mirror the English source, with an accurate and complete translation.headings map and proper legacy heading-map migration.
+
+### ✅ Special characters in headings (23 - lecture)
+
+- **Source PR**: [#667](https://github.com/QuantEcon/test-translation-sync/pull/667)
+- **Target PR**: [#632](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/632)
+- **Translation Score**: 9.6/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: 该翻译质量非常高，准确传达了原文技术含义，术语使用规范，格式完整无语法错误。唯一可改进之处是部分标题及正文中中文字符与行内数学符号（$\LaTeX$、$\beta$、$\mathbb{E}[X]$）之间缺少空格，属于排版细节，建议统一加入空格以与正文其他处保持一致。
+
+**Diff Summary**: The translation sync correctly rewrote the Chinese document to match the completely restructured English source, migrated the legacy heading-map to the translation block, and added the expected state file.
+
+### ✅ Deep nesting (##### and ######) (22 - lecture)
+
+- **Source PR**: [#666](https://github.com/QuantEcon/test-translation-sync/pull/666)
+- **Target PR**: [#631](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/631)
+- **Translation Score**: 9.8/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: An excellent, high-quality translation of the newly added hierarchical economic systems content. Accuracy, terminology, and formatting are near-perfect, with all heading levels and the translation frontmatter correctly handled. Only minor stylistic refinements (e.g., '异议意见' redundancy, tense in the preamble) could marginally improve fluency. No syntax errors detected.
+
+**Diff Summary**: The translation sync correctly overhauled the Chinese document to match the restructured English source, migrating the legacy heading-map to the translation block with accurate, complete mappings.
+
+### ✅ Preamble only changed (frontmatter) (21 - minimal)
+
+- **Source PR**: [#665](https://github.com/QuantEcon/test-translation-sync/pull/665)
+- **Target PR**: [#628](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/628)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified frontmatter/preamble section is excellent. The added translation block is correctly structured with accurate title and heading mappings that match the document body translations. No accuracy, fluency, terminology, formatting, or syntax issues found in the changed sections.
+
+**Diff Summary**: The translation sync correctly mirrored the frontmatter jupytext/kernelspec updates and migrated the legacy heading-map to the translation block with accurate mappings, while preserving document structure and positioning.
+
+### ✅ Document renamed (lecture.md → linear-algebra.md + TOC) (20 - rename)
+
+- **Source PR**: [#664](https://github.com/QuantEcon/test-translation-sync/pull/664)
+- **Target PR**: [#627](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/627)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified sections (frontmatter and 'Applications in Economics') are translated accurately and fluently with all formatting intact. Minor fluency improvements are possible in the economics application paragraph, and the two 'Applications in Economics' headings could be translated more consistently. Overall a high-quality translation.
+
+**Diff Summary**: The translation sync correctly migrated the legacy heading-map to the new translation block, renamed files consistently with the source, and preserved document structure and content positions.
+
+### ✅ Multiple files changed (minimal + lecture) (19 - multi)
+
+- **Source PR**: [#663](https://github.com/QuantEcon/test-translation-sync/pull/663)
+- **Target PR**: [#630](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/630)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: An excellent translation of all the changed and added sections. The content is accurate, fluent, and terminologically consistent with the glossary. MyST/Markdown formatting is fully preserved, and the translation frontmatter block (including the nested Market Dynamics key) is correctly implemented. No syntax errors or quality issues were found in the modified sections.
+
+**Diff Summary**: The Chinese translation correctly mirrors all English source changes in matching positions, preserves structure, and properly migrates the legacy heading-map to the new translation block with complete and accurate mappings.
+
+### ✅ Document deleted (lecture.md + TOC) (18 - toc)
+
+- **Source PR**: [#662](https://github.com/QuantEcon/test-translation-sync/pull/662)
+- **Target PR**: [#626](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/626)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: This PR deleted the document, and both the English source and Chinese translation are empty. There is no translation content to evaluate. No issues or syntax errors can be identified.
+
+**Diff Summary**: The translation sync correctly removed the lecture.md file and its _toc.yml entry in the Chinese target, mirroring the source deletion.
+
+### ✅ New document added (game-theory.md + TOC) (17 - toc)
+
+- **Source PR**: [#661](https://github.com/QuantEcon/test-translation-sync/pull/661)
+- **Target PR**: [#629](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/629)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: This is an excellent, high-quality translation of the added game theory sections. Technical terminology aligns closely with the reference glossary, mathematical and code formatting is fully preserved, and the Chinese reads naturally in an appropriate academic register. No accuracy, fluency, terminology, formatting, or syntax issues were found in the changed sections.
+
+**Diff Summary**: The Chinese translation correctly mirrors the newly added English game-theory document with proper structure and a complete, accurate heading map.
+
+### ✅ Pure section reorder (no content change) (16 - minimal)
+
+- **Source PR**: [#660](https://github.com/QuantEcon/test-translation-sync/pull/660)
+- **Target PR**: [#623](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/623)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified section (the translation frontmatter block) is correctly and accurately implemented. The title '经济学导论' and heading mappings ('Economic Models: 经济模型', 'Supply and Demand: 供给与需求') are all correct and consistent with the document body. The YAML structure is valid and follows the expected translation sync system format. No issues found in the changed section.
+
+**Diff Summary**: The translation sync correctly reordered the two sections in the Chinese document to match the English source and properly migrated the heading-map to the new translation frontmatter format.
+
+### ❌ Sub-subsection deleted (Closure Property) (15 - lecture)
+
+- **Source PR**: [#659](https://github.com/QuantEcon/test-translation-sync/pull/659)
+- **Target PR**: [#625](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/625)
+- **Translation Score**: 9.8/10
+- **Diff Score**: 5/10
+- **Verdict**: FAIL
+
+**Translation Summary**: The changed sections (frontmatter and Basic Properties) are translated with high accuracy and correct terminology. The frontmatter translation block is properly structured. Minor fluency improvements are possible in the Basic Properties list items, but overall the translation is excellent and faithful to the source.
+
+**Diff Summary**: Scope and position are correct and the deleted subsection is mirrored properly; the translation.headings map correctly reflects remaining sections, so the change is essentially correct with only minor structural note about the removed nested heading.
+
+### ✅ Subsection deleted (Matrix Operations) (14 - lecture)
+
+- **Source PR**: [#658](https://github.com/QuantEcon/test-translation-sync/pull/658)
+- **Target PR**: [#622](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/622)
+- **Translation Score**: 9.2/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The changed sections (frontmatter and 'Applications in Economics') are translated accurately with correct terminology and fully preserved formatting. The frontmatter translation block is properly structured with valid nested heading keys. Minor fluency refinements are possible in the economics application paragraph, but overall the translation is high quality with no syntax errors.
+
+**Diff Summary**: The deletion of the Matrix Operations section was correctly mirrored in the Chinese document with proper heading-map migration and cleanup.
+
+### ⚠️ Display math equations changed (13 - lecture)
+
+- **Source PR**: [#657](https://github.com/QuantEcon/test-translation-sync/pull/657)
+- **Target PR**: [#624](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/624)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 7.5/10
+- **Verdict**: WARN
+
+**Translation Summary**: A high-quality, accurate translation that preserves all formatting and mathematical content. The main issue is the inconsistent use of '里昂惕夫' instead of the glossary-mandated '列昂惕夫' for 'Leontief', which appears multiple times in the Matrix Operations section. Fixing this terminology inconsistency would bring the translation to near-perfect quality.
+
+**Diff Summary**: The three intended math annotations were correctly translated and positioned and the heading-map was properly migrated to the translation block, but the target introduced additional out-of-scope edits in the Eigenvalues section that are not present in the English source.
+
+### ✅ Code cell comments/titles changed (12 - lecture)
+
+- **Source PR**: [#656](https://github.com/QuantEcon/test-translation-sync/pull/656)
+- **Target PR**: [#621](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/621)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: A high-quality translation that accurately conveys the source meaning with natural, fluent Chinese and perfectly preserved formatting. The main terminology issue is the consistent use of '里昂惕夫' instead of the glossary-mandated '列昂惕夫' for 'Leontief'. Minor fluency polish is possible in the preamble and the matrix definition sentence, but overall the changed sections are well translated.
+
+**Diff Summary**: The translation sync correctly mirrored the four English source edits into the Chinese target, migrated the legacy heading-map to the translation block, and added the expected state file.
+
+### ✅ Sub-subsection content changed (11 - lecture)
+
+- **Source PR**: [#655](https://github.com/QuantEcon/test-translation-sync/pull/655)
+- **Target PR**: [#619](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/619)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The changed sections (frontmatter, Basic Properties, and Applications in Economics) are translated accurately with well-preserved formatting and correct technical terminology. Minor fluency improvements are possible for a few slightly literal phrasings, but overall the translation is high quality with no syntax errors.
+
+**Diff Summary**: The translation sync correctly modified only the target lecture.md and added the state file, placing changes in the matching 'Basic Properties' section and properly migrating heading-map to the translation block.
+
+### ✅ Sub-subsection added (####) (10 - lecture)
+
+- **Source PR**: [#654](https://github.com/QuantEcon/test-translation-sync/pull/654)
+- **Target PR**: [#617](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/617)
+- **Translation Score**: 8.7/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the changed sections (frontmatter, Applications in Economics, and the newly added Closure Property) is accurate and well-formatted with no syntax errors. Mathematical content is fully preserved. Minor fluency improvements are possible in the Closure Property section where repetitive phrasing ('组合...结果') slightly reduces readability, and there is a minor heading translation inconsistency for the two 'Applications in Economics' sections.
+
+**Diff Summary**: The translation sync correctly added the new 'Closure Property' (封闭性质) subsection in the same relative position as the English source and properly updated the heading map.
+
+### ✅ Real-world lecture update (09 - lecture)
+
+- **Source PR**: [#653](https://github.com/QuantEcon/test-translation-sync/pull/653)
+- **Target PR**: [#620](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/620)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: A high-quality translation that accurately conveys the technical content and reads fluently in Chinese. Formatting and syntax are flawless. The main improvement area is terminology consistency: 'Leontief Inverse' should follow the glossary's '列昂惕夫' rather than the used '里昂惕夫'. A minor point on 'portfolio theory' phrasing. Overall an excellent translation of the modified sections.
+
+**Diff Summary**: The Chinese translation correctly mirrors all English source changes in matching positions, preserves document structure, and properly migrates the heading-map to the translation frontmatter format.
+
+### ✅ Multiple elements changed (08 - minimal)
+
+- **Source PR**: [#652](https://github.com/QuantEcon/test-translation-sync/pull/652)
+- **Target PR**: [#618](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/618)
+- **Translation Score**: 9.8/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The newly added 'Supply and Demand Analysis' and 'Policy Applications' sections, along with the updated preamble, are translated accurately and fluently with correct terminology and preserved formatting. Only minor stylistic refinements are suggested; no syntax or accuracy errors were found.
+
+**Diff Summary**: The translation sync correctly mirrored all English source changes into the Chinese target with proper positioning, preserved structure, and an accurate migrated translation.headings map.
+
+### ✅ Subsection content updated (07 - minimal)
+
+- **Source PR**: [#651](https://github.com/QuantEcon/test-translation-sync/pull/651)
+- **Target PR**: [#616](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/616)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: Excellent translation of the modified sections. The preamble, Supply and Demand section, and the newly added Market Equilibrium section are all accurately and fluently translated with correct terminology and preserved formatting. The translation frontmatter with heading map is correctly structured. No issues found.
+
+**Diff Summary**: The translation sync correctly added the new 'Market Equilibrium' subsection in the matching position, preserved structure, and properly migrated the legacy heading-map to the translation block with correct path-based mapping.
+
+### ✅ Section removed (06 - minimal)
+
+- **Source PR**: [#650](https://github.com/QuantEcon/test-translation-sync/pull/650)
+- **Target PR**: [#615](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/615)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The changed sections (frontmatter and the deletion of the Economic Models section) are handled correctly. The translation frontmatter block properly reflects the current document structure, mapping only the title and 'Supply and Demand' heading, with no stale reference to the deleted Economic Models section. Terminology is consistent with the glossary and no syntax or formatting errors are present.
+
+**Diff Summary**: The translation sync correctly removed the 'Economic Models' section from the Chinese document matching the source deletion, migrated the legacy heading-map to the new translation format, and updated the headings map appropriately.
+
+### ✅ New section added (05 - minimal)
+
+- **Source PR**: [#649](https://github.com/QuantEcon/test-translation-sync/pull/649)
+- **Target PR**: [#613](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/613)
+- **Translation Score**: 9.8/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: 本次 PR 修改的 frontmatter 和新增的 'Market Equilibrium' 章节翻译质量优秀。术语使用与参考词汇表完全一致，格式与语法均无问题。translation 块正确映射了新章节标题。唯一可微调之处是 '在这一点上' 稍显直译，但不影响理解。
+
+**Diff Summary**: The translation sync correctly added the new 'Market Equilibrium' section in the matching position, migrated the legacy heading-map to the translation block, and updated all mappings appropriately.
+
+### ✅ Sections reordered and content changed (04 - minimal)
+
+- **Source PR**: [#648](https://github.com/QuantEcon/test-translation-sync/pull/648)
+- **Target PR**: [#614](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/614)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The changed sections (frontmatter and Economic Models) are translated with high accuracy, natural fluency, and correct terminology. The translation frontmatter block is properly structured, and no syntax or formatting errors are present. This is an excellent translation of the modified content.
+
+**Diff Summary**: The translation sync correctly reordered the two sections to match the source, updated the content edit in the Economic Models section, and properly migrated the legacy heading-map to the translation block.
+
+### ✅ Section content updated (03 - minimal)
+
+- **Source PR**: [#647](https://github.com/QuantEcon/test-translation-sync/pull/647)
+- **Target PR**: [#612](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/612)
+- **Translation Score**: 9.8/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: An excellent, accurate translation of the modified sections. The frontmatter translation block is correctly structured, and the Supply and Demand section faithfully conveys the source meaning using proper economics terminology. Only minor stylistic refinements are suggested (e.g., '价格水平' over '价格点'), none of which affect correctness.
+
+**Diff Summary**: The translation sync correctly modified only the relevant files, positioned changes in the matching 'Supply and Demand' section, preserved document structure, and properly migrated the legacy heading-map to the new translation block.
+
+### ✅ Title changed (02 - minimal)
+
+- **Source PR**: [#646](https://github.com/QuantEcon/test-translation-sync/pull/646)
+- **Target PR**: [#611](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/611)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified frontmatter block is correctly implemented. The translation.title accurately reflects the document title, and the heading mappings correctly link English section headings to their Chinese translations. The keys preserve the original English heading text as required, and the values match the actual translated headings in the document body. No syntax or formatting issues were found in the changed section.
+
+**Diff Summary**: The translation sync correctly updated only the title change in the same position, preserved structure, and properly migrated the legacy heading-map to the new translation block.
+
+### ✅ Intro text updated (01 - minimal)
+
+- **Source PR**: [#645](https://github.com/QuantEcon/test-translation-sync/pull/645)
+- **Target PR**: [#610](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/610)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified frontmatter section is excellent. The added translation block correctly maps the English title and section headings to their Chinese equivalents, following the reference glossary exactly. The YAML syntax is valid and the translation feature block is properly structured. No issues found in the changed sections.
+
+**Diff Summary**: The translation sync correctly modified only the intended files, positioned the changed paragraph in the matching section, preserved structure, and properly migrated the legacy heading-map to the translation block.
+

--- a/tool-test-action-on-github/reports/evaluation-2026-07-15-sonnet5-v2.md
+++ b/tool-test-action-on-github/reports/evaluation-2026-07-15-sonnet5-v2.md
@@ -1,0 +1,324 @@
+# Translation Evaluation Report
+
+**Generated**: 2026-07-15T10:34:04.096Z
+**Evaluator**: claude-opus-4-5-20251101
+**Source Repository**: QuantEcon/test-translation-sync
+**Target Repository**: QuantEcon/test-translation-sync.zh-cn
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| PR Pairs Evaluated | 25 |
+| Passed ✅ | 25 |
+| Warnings ⚠️ | 0 |
+| Failed ❌ | 0 |
+| Avg Translation Score | 9.4/10 |
+| Avg Diff Score | 10/10 |
+
+---
+
+## Per-PR Results
+
+### ✅ Heading case change (title-case → sentence-case) (26 - lecture)
+
+- **Source PR**: [#670](https://github.com/QuantEcon/test-translation-sync/pull/670)
+- **Target PR**: [#635](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/635)
+- **Translation Score**: 9.2/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: 翻译质量整体优秀，准确传达了线性代数基础概念及其在经济学中的应用。数学公式、代码块格式完整保留。主要问题是'Leontief'的译名与术语表不一致（应为'列昂惕夫'而非'里昂惕夫'），其他表述基本流畅自然。
+
+**Diff Summary**: Translation sync correctly updated heading keys from title case to sentence case and migrated from heading-map to translation format.
+
+### ✅ Pre-title content (anchor + raw block) (25 - lecture)
+
+- **Source PR**: [#669](https://github.com/QuantEcon/test-translation-sync/pull/669)
+- **Target PR**: [#634](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/634)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the modified sections is of high quality. The preamble/frontmatter correctly includes the translation mapping block. The 'Applications in Economics' section accurately conveys the economic concepts with proper terminology. The 'Eigenvalues and Eigenvectors' section maintains mathematical rigor while being readable in Chinese. Minor improvements could be made to sentence flow, but overall the translation is accurate and professional.
+
+**Diff Summary**: Translation sync correctly propagated the cross-reference target, raw jupyter header block, and index directive changes from English to Chinese, with proper frontmatter migration from heading-map to translation format.
+
+### ✅ Empty sections (heading only) (24 - minimal)
+
+- **Source PR**: [#668](https://github.com/QuantEcon/test-translation-sync/pull/668)
+- **Target PR**: [#633](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/633)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: 整体翻译质量优秀。新增章节的术语翻译准确规范，完全符合参考术语表。文档结构和格式保留完整。译文流畅自然，适合学术语境。仅有少量表述可进一步优化，但不影响理解。
+
+**Diff Summary**: Translation sync correctly transformed the document from a simple 3-section introduction to a comprehensive 16-section economic framework with proper structure and heading mappings.
+
+### ✅ Special characters in headings (23 - lecture)
+
+- **Source PR**: [#667](https://github.com/QuantEcon/test-translation-sync/pull/667)
+- **Target PR**: [#632](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/632)
+- **Translation Score**: 9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: This is a high-quality translation that accurately conveys the technical content while maintaining natural Chinese expression. All formatting elements including code blocks, LaTeX equations, and special markdown syntax are properly preserved. The translation follows established terminology conventions and reads fluently as academic Chinese text. Minor suggestions relate to optional stylistic improvements rather than errors.
+
+**Diff Summary**: The translation sync correctly replaced the entire Linear Algebra document with a new Programming for Economics document, with proper structure, positioning, and complete heading map migration from legacy `heading-map:` to `translation:` format.
+
+### ✅ Preamble only changed (frontmatter) (21 - minimal)
+
+- **Source PR**: [#665](https://github.com/QuantEcon/test-translation-sync/pull/665)
+- **Target PR**: [#628](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/628)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified frontmatter section is correctly formatted. The translation block properly includes the document title and heading mappings following the expected structure. The YAML syntax is valid and all metadata fields are preserved correctly. No issues found in the changed sections.
+
+**Diff Summary**: Translation sync correctly migrated from legacy heading-map to translation block and updated jupytext metadata to match source changes.
+
+### ✅ Document renamed (lecture.md → linear-algebra.md + TOC) (20 - rename)
+
+- **Source PR**: [#664](https://github.com/QuantEcon/test-translation-sync/pull/664)
+- **Target PR**: [#627](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/627)
+- **Translation Score**: 9.2/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the modified sections is of high quality. The frontmatter translation block is correctly structured with proper heading mappings. The 'Applications in Economics' section accurately conveys the economic concepts about vector space properties. There is a minor terminology inconsistency with 'Leontief Inverse' (里昂惕夫 vs 列昂惕夫), though both romanizations are used in Chinese literature. Overall, the translation is accurate, fluent, and well-formatted.
+
+**Diff Summary**: The translation sync correctly migrated the frontmatter from legacy heading-map to the new translation format, with appropriate file rename tracking in both _toc.yml and state file.
+
+### ✅ Multiple files changed (minimal + lecture) (19 - multi)
+
+- **Source PR**: [#663](https://github.com/QuantEcon/test-translation-sync/pull/663)
+- **Target PR**: [#630](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/630)
+- **Translation Score**: 9.2/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the changed sections is of high quality. The economic concepts are accurately conveyed, the Chinese reads naturally with appropriate academic register, and all formatting is properly preserved. The translation frontmatter correctly maps the English headings to their Chinese equivalents. Minor suggestions relate to alternative word choices that could marginally improve precision, but the current translation is fully acceptable for academic content.
+
+**Diff Summary**: Translation sync correctly updated the Chinese document with all structural changes, new sections, and properly migrated from legacy heading-map to the translation frontmatter format.
+
+### ✅ Document deleted (lecture.md + TOC) (18 - toc)
+
+- **Source PR**: [#662](https://github.com/QuantEcon/test-translation-sync/pull/662)
+- **Target PR**: [#626](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/626)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: This PR involves a document deletion. Since the document was deleted (both English source and Chinese translation are empty), there is no translation content to evaluate. The deletion itself is the intended change, and there are no translation quality issues to report.
+
+**Diff Summary**: The English source file was removed, and the corresponding Chinese translation file was correctly removed as well, maintaining sync between source and target.
+
+### ✅ New document added (game-theory.md + TOC) (17 - toc)
+
+- **Source PR**: [#661](https://github.com/QuantEcon/test-translation-sync/pull/661)
+- **Target PR**: [#629](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/629)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: This is a high-quality translation of game theory content. The translation accurately conveys all technical concepts, follows the established glossary terminology consistently, and maintains excellent formatting. Minor issues include some untranslated English terms within mathematical expressions and a slightly less common term choice for 'subgame perfection'. The overall translation is professional and suitable for academic use.
+
+**Diff Summary**: New game theory document correctly translated with proper structure, positioning, and complete heading map.
+
+### ✅ Pure section reorder (no content change) (16 - minimal)
+
+- **Source PR**: [#660](https://github.com/QuantEcon/test-translation-sync/pull/660)
+- **Target PR**: [#623](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/623)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified preamble/frontmatter section is correctly implemented. The translation block follows the expected format with proper title and headings mapping. The YAML syntax is correct and the structure aligns with the translation sync system requirements. No issues found in the changed sections.
+
+**Diff Summary**: Translation sync correctly reordered sections to match source document and properly migrated from legacy heading-map to translation format.
+
+### ✅ Sub-subsection deleted (Closure Property) (15 - lecture)
+
+- **Source PR**: [#659](https://github.com/QuantEcon/test-translation-sync/pull/659)
+- **Target PR**: [#625](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/625)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the modified sections (preamble/frontmatter and Basic Properties) is excellent. The frontmatter correctly implements the translation block with proper heading mappings including the nested 'Vector Spaces::Basic Properties' notation. The Basic Properties section accurately conveys the mathematical concepts with appropriate Chinese terminology for closure, additive identity (零向量), and additive inverses. Only minor fluency improvement possible in one phrase.
+
+**Diff Summary**: The translation sync correctly removed the 'Applications in Economics' subsection under 'Basic Properties' and properly updated the frontmatter from legacy 'heading-map' to 'translation' format.
+
+### ✅ Subsection deleted (Matrix Operations) (14 - lecture)
+
+- **Source PR**: [#658](https://github.com/QuantEcon/test-translation-sync/pull/658)
+- **Target PR**: [#622](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/622)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the changed sections is of high quality. The preamble/frontmatter correctly implements the translation mapping system with proper YAML structure. The 'Applications in Economics' section accurately conveys the economic concepts with appropriate terminology. Minor fluency improvements could be made to make some phrases sound more natural in Chinese academic writing. The deletion of the 'Matrix Operations' section is correctly reflected by its absence in the translation.
+
+**Diff Summary**: The translation sync correctly removed the Matrix Operations section from the Chinese document to match the English source deletion, and properly migrated from heading-map to translation format.
+
+### ✅ Display math equations changed (13 - lecture)
+
+- **Source PR**: [#657](https://github.com/QuantEcon/test-translation-sync/pull/657)
+- **Target PR**: [#624](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/624)
+- **Translation Score**: 9.2/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: Excellent translation quality for the changed sections. The technical mathematical content is accurately preserved, terminology follows the glossary consistently, and the Chinese reads naturally for an academic audience. Minor suggestions are stylistic preferences rather than errors. All MyST formatting, code blocks, and mathematical equations are correctly maintained.
+
+**Diff Summary**: Translation sync correctly applied mathematical notation enhancements to the Chinese document in matching positions, with proper migration from heading-map to translation format.
+
+### ✅ Code cell comments/titles changed (12 - lecture)
+
+- **Source PR**: [#656](https://github.com/QuantEcon/test-translation-sync/pull/656)
+- **Target PR**: [#621](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/621)
+- **Translation Score**: 9.2/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: 翻译质量整体优秀，准确传达了原文的技术内容。数学公式和代码格式完整保留，专业术语使用规范。仅有少量表达可以更加流畅自然，但不影响理解。
+
+**Diff Summary**: Translation sync correctly updated Chinese document with minor code comment changes and properly migrated heading-map to translation format.
+
+### ✅ Sub-subsection content changed (11 - lecture)
+
+- **Source PR**: [#655](https://github.com/QuantEcon/test-translation-sync/pull/655)
+- **Target PR**: [#619](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/619)
+- **Translation Score**: 9.2/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the modified sections (preamble, Basic Properties, and Applications in Economics) is of high quality. The frontmatter correctly includes the translation block with heading mappings. The Basic Properties section accurately translates the vector space axioms using proper mathematical terminology. The Applications in Economics section faithfully conveys the economic modeling context. Minor improvements could be made to sentence flow, but overall the translation is accurate, fluent, and maintains proper formatting.
+
+**Diff Summary**: Translation sync correctly updated the Basic Properties section content and migrated from legacy heading-map to translation format.
+
+### ✅ Sub-subsection added (####) (10 - lecture)
+
+- **Source PR**: [#654](https://github.com/QuantEcon/test-translation-sync/pull/654)
+- **Target PR**: [#617](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/617)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the changed sections (preamble, Applications in Economics, and Closure Property) is of high quality. The frontmatter translation block is correctly formatted with proper heading mappings. The mathematical content is accurately conveyed, and the economic concepts are translated using appropriate Chinese terminology. Minor improvements could be made to terminology choices, but overall the translation reads naturally and maintains technical accuracy.
+
+**Diff Summary**: Translation sync correctly added the new 'Closure Property' section with proper positioning and updated the translation frontmatter from legacy heading-map format to the new translation format.
+
+### ✅ Real-world lecture update (09 - lecture)
+
+- **Source PR**: [#653](https://github.com/QuantEcon/test-translation-sync/pull/653)
+- **Target PR**: [#620](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/620)
+- **Translation Score**: 8.9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: This is a high-quality translation of the linear algebra foundations lecture. The changed sections are accurately translated with proper preservation of mathematical content and code blocks. The main terminology issue is the inconsistent transliteration of 'Leontief' (里昂惕夫 vs. the glossary standard 列昂惕夫). The translation reads naturally in Chinese while maintaining technical precision appropriate for an economics audience.
+
+**Diff Summary**: Translation sync correctly applied all source changes to corresponding positions in the Chinese document with proper frontmatter migration.
+
+### ✅ Multiple elements changed (08 - minimal)
+
+- **Source PR**: [#652](https://github.com/QuantEcon/test-translation-sync/pull/652)
+- **Target PR**: [#618](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/618)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the changed sections is of high quality. The newly added 'Supply and Demand Analysis' and 'Policy Applications' sections are accurately translated with proper economic terminology. The frontmatter has been correctly updated with the translation mapping block. Minor suggestions relate to word order preferences that are stylistic rather than errors. The translation successfully conveys the economic concepts while maintaining natural Chinese academic prose.
+
+**Diff Summary**: Translation sync correctly updated the Chinese document with all source changes, properly migrated from heading-map to translation format, and maintained document structure.
+
+### ✅ Subsection content updated (07 - minimal)
+
+- **Source PR**: [#651](https://github.com/QuantEcon/test-translation-sync/pull/651)
+- **Target PR**: [#616](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/616)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the modified sections is of high quality. The Supply and Demand section and the newly added Market Equilibrium section are accurately translated with natural Chinese expression and proper academic terminology. The frontmatter translation block is correctly structured with the nested heading path notation. Only a minor stylistic suggestion for one phrase in the Market Equilibrium section.
+
+**Diff Summary**: Translation sync correctly added the new 'Market Equilibrium' subsection in the same position as the source and properly updated the frontmatter from legacy heading-map to translation format.
+
+### ✅ Section removed (06 - minimal)
+
+- **Source PR**: [#650](https://github.com/QuantEcon/test-translation-sync/pull/650)
+- **Target PR**: [#615](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/615)
+- **Translation Score**: 9.9/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the modified preamble/frontmatter section is well-executed. The YAML frontmatter properly includes the translation block with correct Chinese title and heading mappings. The only minor issue is that the translation.headings map appears to include an entry for 'Economic Models' which corresponds to the DELETED section - this orphaned mapping could be cleaned up. The deletion of the '## Economic Models' section has been properly handled in the document body.
+
+**Diff Summary**: The translation sync correctly removed the 'Economic Models' section from the Chinese document and properly migrated from legacy 'heading-map' to the new 'translation' frontmatter format.
+
+### ✅ New section added (05 - minimal)
+
+- **Source PR**: [#649](https://github.com/QuantEcon/test-translation-sync/pull/649)
+- **Target PR**: [#613](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/613)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the changed sections is of high quality. The frontmatter correctly includes the translation mapping for the new 'Market Equilibrium' heading. The newly added Market Equilibrium section accurately conveys the economic concepts with proper terminology. There is one minor fluency issue with the phrase '在这一点上' which could be slightly more natural, but overall the translation reads well and maintains academic tone.
+
+**Diff Summary**: Translation sync correctly added the new 'Market Equilibrium' section at the end of the document with proper heading map migration from legacy format.
+
+### ✅ Sections reordered and content changed (04 - minimal)
+
+- **Source PR**: [#648](https://github.com/QuantEcon/test-translation-sync/pull/648)
+- **Target PR**: [#614](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/614)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the modified sections (preamble/frontmatter and Economic Models) is of high quality. The YAML frontmatter correctly includes the translation block with proper heading mappings. The Economic Models section accurately conveys the meaning of simplified representations and the role of assumptions in economic modeling. Only a minor fluency improvement is suggested for one sentence structure.
+
+**Diff Summary**: Translation sync correctly reordered sections to match the English source and migrated from legacy heading-map to translation format.
+
+### ✅ Section content updated (03 - minimal)
+
+- **Source PR**: [#647](https://github.com/QuantEcon/test-translation-sync/pull/647)
+- **Target PR**: [#612](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/612)
+- **Translation Score**: 9.4/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The translation of the modified sections (frontmatter and Supply and Demand) is of high quality. The Supply and Demand section accurately conveys the economic concepts with natural Chinese phrasing and correctly applies the glossary term '市场出清'. The frontmatter translation block is properly structured. No syntax errors were found.
+
+**Diff Summary**: Translation sync correctly updated the Supply and Demand section content and properly migrated from legacy heading-map to translation format.
+
+### ✅ Title changed (02 - minimal)
+
+- **Source PR**: [#646](https://github.com/QuantEcon/test-translation-sync/pull/646)
+- **Target PR**: [#611](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/611)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified section (preamble/frontmatter) is correctly translated. The YAML frontmatter preserves all technical metadata (jupytext configuration, kernelspec) while adding the appropriate translation block with title and headings mappings. The format follows the expected structure with 'translation.title' containing the Chinese title and 'translation.headings' mapping English heading text to Chinese translations.
+
+**Diff Summary**: Title change from 'Introduction to Economics' to 'Principles of Economic Analysis' was correctly synced with proper frontmatter migration from heading-map to translation format.
+
+### ✅ Intro text updated (01 - minimal)
+
+- **Source PR**: [#645](https://github.com/QuantEcon/test-translation-sync/pull/645)
+- **Target PR**: [#610](https://github.com/QuantEcon/test-translation-sync.zh-cn/pull/610)
+- **Translation Score**: 10/10
+- **Diff Score**: 10/10
+- **Verdict**: PASS
+
+**Translation Summary**: The modified preamble/frontmatter section is correctly translated. The translation block has been properly added with the Chinese title '经济学导论' and accurate heading mappings for 'Supply and Demand' → '供给与需求' and 'Economic Models' → '经济模型'. All original YAML metadata is preserved intact. No issues found in the changed sections.
+
+**Diff Summary**: Translation sync correctly updated the introductory paragraph with appropriate Chinese translation and properly migrated from legacy heading-map to translation format.
+


### PR DESCRIPTION
Follow-up to #86, closing the last gap in making harness baselines trustworthy.

## The bug

`.gitignore` has a bare `reports/`, which git matches at **any** depth — so `tool-test-action-on-github/reports/` was ignored along with the repo-root one it was written for (its own comment says *"output of CLI tools"*, i.e. what `translate backward -o reports/` writes).

The 2025-12 reports are tracked only because they were committed *before* that rule landed. Every baseline generated since has silently failed to be added — you'd have to `git add -f` and nobody knew to. That is very likely why there are **no reports between 2025-12 and today**, and it would have quietly swallowed the v0.16.1 baselines too.

Fixed by anchoring the rule to the repo root: `/reports/`. Verified both ways — root `reports/` still ignored, `tool-test-action-on-github/reports/` no longer.

## What's committed

| report | action model | judge |
|---|---|---|
| `evaluation-2026-07-15-sonnet5-v2.md` | Sonnet 5 (v0.16.1) | `claude-opus-4-5-20251101` — pinned to the 2025-12 baseline's judge |
| `evaluation-2026-07-15-sonnet5-opus48.md` | Sonnet 5 (v0.16.1) | `claude-opus-4-8` — current-generation, absolute read |

The first Opus-4.5 run is deliberately **not** committed: it predates the rubric fix in #86, so its 9.2/7.7 scores measure rubric staleness rather than translation quality. Keeping it would invite exactly the false comparison this PR is trying to prevent.

The README now records, per report, which model produced the translations and which graded them — plus the two rules that make these numbers usable: pin the judge to the baseline's when comparing, and treat a denominator below the scenario count as an incomplete run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)