### PR TITLE
chore(dev): track review follow-ups; estate on v0.16.1; distil STATE

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -7,44 +7,29 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## In flight
 
-- **PR #87** — commit the v0.16.1 harness baselines + fix `.gitignore`'s bare `reports/`
-  silently ignoring `tool-test-action-on-github/reports/` (why no baselines exist between
-  2025-12 and now).
-- **Estate upgrade to v0.16.1** — 9 pins across 4 repos: lecture-python-programming#575
-  (3 sync workflows), .zh-cn#69, .fa#132, .fr#5 (rebase + review each). Catalogue:
-  QuantEcon/project-translation#7.
 - **PR #78** — fr programming-domain glossary terms; awaiting native review.
 - **PR #71** — Malayalam (`ml`) draft; awaiting native-reviewer calibration batch.
   Glossary PR **#69** (ja) open, awaiting native review + a `LANGUAGE_CONFIGS` entry.
 
 ## Recently landed
 
-- **v0.16.1 released** 2026-07-15 — the #83 fixes; `v0`/`v0.16` moved to it (moving the
-  floating tags is now an explicit release-checklist step, both commands spelled out).
-- **PR #86** merged — harness trustworthiness: templates pinned to the release under test;
-  evaluator judge default → `claude-opus-4-8` (comparisons pin to the baseline's judge,
-  recorded in each report's `**Evaluator**:` header); rubric updated to the `translation:`
-  frontmatter format (it had described the pre-v0.13.0 `heading-map:` since 2025-12, marking
-  every PR down for being correct); dropped pairs no longer vanish silently; documents no
-  longer truncated at 4000 chars before the diff judge.
-- **Sonnet 5 validated for zh-cn/fa** — 26/26 correct PRs per language on the e2e harness;
-  9.4/10 translation, 10/10 diff vs the Dec-2025 Sonnet 4.5 baseline's 9.5/10 (same judge);
-  9.6/10 under an Opus 4.8 judge. Answers project-translation#5 — note 4.6 (what they run
-  today) was itself never measured. `.dev/decisions/D-2026-07-15-sonnet5-validated.md`.
-- **fr footnote corruption repaired** — lecture-python-programming.fr#4 merged.
-- **PR #83** merged 2026-07-15 (squash, `bb17926`) — high-severity fixes from the
-  2026-07-15 deep review (`REVIEW-FABLE5-2026-07-15.md`): fr typography definition-label
-  fix, LICENSE, lint-glob fix + prettier + CI format gate + `--max-warnings 0`,
-  PLAN Phase 1 pagination/CRLF/stop_reason/content[0]/glossary fixes, in-range dep
-  advisories, docs [H] accuracy fixes. Unreleased on `main` — v0.16.1 is the next chore.
-- **v0.16.0** released 2026-07-15 — default model → `claude-sonnet-5` (centralized in
-  `src/models.ts`), thinking OFF (settled: D-2026-07-14), deterministic fr typography
-  (`init` path only — sync wiring is issue #81), glossary-review tooling + skill.
-- **`v0` floating tag moved to v0.16.0** (was stuck at v0.7.0-era, 115 commits behind,
-  with README recommending `@v0`). Moving `v0` is now a release step.
-- **fr is in production**: `lecture-python-programming.fr` exists with a sync workflow
-  pinned `@v0.16.0`. Note: zh-cn/fa workflows pin `@v0.15.0` → those languages translate
-  with Sonnet 4.6 while fr uses Sonnet 5 (decide: deliberate staging or drift?).
+- **Estate upgraded to v0.16.1** — all 9 pins across 4 repos (lecture-python-programming#575,
+  .zh-cn#69, .fa#132, .fr#5). First time the estate is on one version; it spanned
+  v0.13.0–v0.16.0 that morning. **zh-cn and fa now translate with Sonnet 5.** Deployment
+  catalogue: QuantEcon/project-translation#7.
+- **v0.16.0 and v0.16.1 released** — v0.16.0 was the Sonnet 5 default + `models.ts` + fr
+  typography (`init` path only; sync wiring is #81); v0.16.1 the deep-review fixes (#83).
+  `v0`/`v0.16` now move as an explicit, spelled-out release-checklist step — `v0` had sat on
+  v0.7.0-era code for 9 releases while the README recommended it.
+- **Sonnet 5 validated for zh-cn/fa** — 26/26 correct PRs per language; 9.4/10 translation vs
+  the Dec-2025 Sonnet 4.5 baseline's 9.5 (same judge), 9.6 under Opus 4.8. Answers
+  QuantEcon/project-translation#5; note 4.6 — what they ran before — was never measured.
+  See decisions/D-2026-07-15-sonnet5-validated.md.
+- **Harness made trustworthy** (#86, #87) — it had been confidently wrong three ways: rubric
+  frozen at the pre-v0.13.0 `heading-map:` format, documents truncated at 4000 chars
+  (asymmetric en↔zh), pairs dropped silently. Baselines now committed — `.gitignore`'s bare
+  `reports/` had been swallowing them since 2025-12.
+- **fr footnote corruption repaired** — lecture-python-programming.fr#4.
 
 ## Blocked
 
@@ -52,10 +37,11 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## Next
 
-- Merge the estate upgrade to v0.16.1 (4 PRs, 9 pins — see In flight). Merging the source
-  PR is the moment Sonnet 5 starts producing real zh-cn/fa translations; watch the first
-  real sync for the new truncation guard firing on a long lecture (correct behaviour, but
-  it surfaces as a loud failure where output was previously silently truncated).
+- **Watch the first real zh-cn/fa syncs** — the estate upgrade landed, so the next merged
+  lecture PR is the first production Sonnet 5 translation. Two things to expect that look
+  like regressions but are not: the new truncation guard may fail a long lecture that
+  previously produced silently-truncated output (#83), and pagination now processes >30-file
+  PRs completely, so a large PR costs more and produces a bigger diff than before.
 - **PLAN Phase 1 remainder**: rebase no-op comments, `context.sha` vs `merge_commit_sha`,
   resync fail-closed, `@actions/*` + SDK major bumps (pair with node24, PLAN 5.8),
   rebase input-validation hardening (1.5).

--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -59,11 +59,16 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 - **PLAN Phase 1 remainder**: rebase no-op comments, `context.sha` vs `merge_commit_sha`,
   resync fail-closed, `@actions/*` + SDK major bumps (pair with node24, PLAN 5.8),
   rebase input-validation hardening (1.5).
-- **node24 is no longer optional** (PLAN 5.8): the 2026-07-15 harness run shows GitHub
-  already overriding `action.yml`'s `using: node20` — *"The following actions target Node.js
-  20 but are being forced to run on Node.js 24: ./action"* — on every run, in production
-  too. We are getting the runtime without having declared or tested for it.
-- New issues from the review round: **#81** (typography on sync path), **#82** (model-swap
+- **#89 node24 + `@actions/*` majors** — GitHub already force-runs the action on Node 24
+  despite `action.yml` declaring node20 (harness evidence, every run). Also clears the last
+  prod advisories (undici via `@actions/*`). PLAN 5.8 + 1.4, one release.
+- **#90 silent data loss in the sync merge path** — five ways translations vanish or English
+  leaks in while the run reports success (REVIEW §6.1). Not covered by PLAN Phase 2; the
+  Phase 2 round-trip test would catch three of them as a class, so Phase 2 first.
+- Smaller review-round follow-ups: **#91** (heading-maps.md documents a key format the action
+  has never written — nearly caused a bad rubric fix), **#92** (PR creation reports failure
+  when the API times out *after* succeeding; naive retry would duplicate).
+- Earlier review-round issues: **#81** (typography on sync path), **#82** (model-swap
   eval — see REVIEW §7.4 for a concrete deterministic design).
 
 ## Health & context

--- a/.dev/log/2026-07-15-f5rev.md
+++ b/.dev/log/2026-07-15-f5rev.md
@@ -35,3 +35,8 @@ QuantEcon tooling, not just here.
 Estate upgrade opened (9 pins, 4 repos) + catalogue at project-translation#7, which also
 surfaced that the action is wired on only ONE series — intro/intermediate have zh-cn
 editions in manifest.yml with no workflows at all.
+
+Estate upgrade merged: all 9 pins across 4 repos on v0.16.1 — first time the estate is on
+one version (spanned v0.13.0–v0.16.0 that morning). zh-cn and fa now translate with Sonnet 5;
+the next merged lecture PR is the first production Sonnet 5 translation. Remaining review
+findings tracked as #89-#92.


### PR DESCRIPTION
`.dev`-only. Two things, both bookkeeping for the end of the 2026-07-15 review round.

**1. The review's remaining findings now have issues**, and `STATE.md`'s `Next` points at them so tomorrow starts from links rather than prose to re-derive:

- **#89** — node24 + the `@actions/*` majors. GitHub already force-runs the action on Node 24 despite `action.yml` declaring node20; also the only way to clear the last prod advisories (undici).
- **#90** — silent data loss in the sync merge path: five ways translations vanish or English leaks in while the run reports success. Not covered by PLAN Phase 2 — though Phase 2's round-trip test would catch three of them as a class, which is the argument for Phase 2 first.
- **#91** — `heading-maps.md` documents a key format the action has never written.
- **#92** — PR creation reports failure when the API times out *after* succeeding.

**2. The estate upgrade landed** — all 9 pins across 4 repos on v0.16.1, the first time the estate has been on one version (it spanned v0.13.0–v0.16.0 this morning). zh-cn and fa translate with Sonnet 5 from here.

`STATE.md` is also distilled back to its ~1-page budget. `Recently landed` had grown to 8 narrative entries and still carried two claims the day had falsified — #83 described as "unreleased on main", and "zh-cn/fa pin v0.15.0 — deliberate staging or drift?", which the upgrade answers. `Next` now leads with what to watch on the first real Sonnet 5 syncs: the truncation guard may fail a long lecture that previously produced silently-truncated output, and pagination now processes >30-file PRs completely — both correct behaviour, both will look like regressions the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)