### PR TITLE
chore: release v0.18.0

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -1,4 +1,4 @@
-verified: 2026-07-15
+verified: 2026-07-18
 
 # STATE
 
@@ -7,24 +7,29 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## In flight
 
-- **PR #98** — #96: duplicate review comments under concurrent runs (unsynchronised upsert).
-  Marker + delete-older-ids reconciliation; also adds the `concurrency` group missing from
-  all four review workflow templates, which is where `.fr`/`.fa` inherited the 5x review
-  spend. Decision: `decisions/D-2026-07-16-single-review-comment.md`.
 - **PR #78** — fr programming-domain glossary terms; awaiting native review.
 - **PR #71** — Malayalam (`ml`) draft; awaiting native-reviewer calibration batch.
   Glossary PR **#69** (ja) open, awaiting native review + a `LANGUAGE_CONFIGS` entry.
 
 ## Recently landed
 
+- **v0.18.0** (2026-07-18; tagged + published on merge) — forward-resync integrity day:
+  #108 fixed the `forward --github` Tier-1 cluster from the intro.zh-cn drift wave —
+  #105 (state + heading map committed with content, target frontmatter carried, stray `---`
+  fixed), #104 (resync PRs reviewable via `translation-sync-metadata` fallback), the
+  mechanical halves of #106 (flag-based discovery, outcome-based summary), #107 prompt
+  hardening (localisation as ground truth — **unvalidated**, needs a wave). #110 closed
+  #102 (criterion-score validation; incomplete review = retry/error, never FAIL). #111
+  declared node24 + bumped `@actions/*` to the CJS majors — prod advisories now 0.
+  Smoke-tested live on test-translation-sync.fa#78 (both halves). Estate pins on v0.16.1 —
+  two releases behind; bumping them is the natural next step.
 - **v0.17.0** (2026-07-16; tagged + published on merge of #101) — typography-erosion day:
   #99 wired `applyTypography`
   into the sync path (issue #97: every fr sync stripped the seed's NBSP; numba.md 27→14 in
   one merge, restored by .fr#9 backfill), #100 made heading matching typography-insensitive
   (`normalizeHeadingForMatch`, exact-first + ambiguity guard; also forward-resync typesetting,
   headingmap/apply.mjs ping-pong, role-stripped key lookups, the deleted `[0.16.1]` CHANGELOG
-  header). #98 fixed duplicate review comments under concurrent runs. Estate pins still on
-  v0.16.1 — bumping them is the natural next step.
+  header). #98 fixed duplicate review comments under concurrent runs.
 - **Estate upgraded to v0.16.1** — all 9 pins across 4 repos (lecture-python-programming#575,
   .zh-cn#69, .fa#132, .fr#5). First time the estate is on one version; it spanned
   v0.13.0–v0.16.0 that morning. **zh-cn and fa now translate with Sonnet 5.** Deployment
@@ -57,9 +62,6 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 - **PLAN Phase 1 remainder**: rebase no-op comments, `context.sha` vs `merge_commit_sha`,
   resync fail-closed, `@actions/*` + SDK major bumps (pair with node24, PLAN 5.8),
   rebase input-validation hardening (1.5).
-- **#89 node24 + `@actions/*` majors** — GitHub already force-runs the action on Node 24
-  despite `action.yml` declaring node20 (harness evidence, every run). Also clears the last
-  prod advisories (undici via `@actions/*`). PLAN 5.8 + 1.4, one release.
 - **#90 silent data loss in the sync merge path** — five ways translations vanish or English
   leaks in while the run reports success (REVIEW §6.1). Not covered by PLAN Phase 2; the
   Phase 2 round-trip test would catch three of them as a class, so Phase 2 first.
@@ -73,11 +75,12 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## Health & context
 
-- `main` green; ~1,068 tests (40 suites), lint now actually covers all 78 files
+- `main` green; 1,143 tests (47 suites), lint covers all files
   (`--max-warnings 0`) and CI checks formatting.
 - Highest-priority known bug: issue **#65** — translator drops `(label)=` anchors
   (PLAN Phase 2), plus the silent-data-loss family documented in REVIEW §6.1.
-- Prod dep advisories: 1 high / 2 moderate remaining (undici via `@actions/*` majors).
+- Prod dep advisories: **0** (cleared by #111's `@actions/*` CJS majors; the ESM-only
+  3.x/9.x lines remain tracked in #89).
 
 ## Map
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@
 - **Review Mode**: Runs in TARGET repo, posts quality review comments on translation PRs
 - **Rebase Mode**: Runs in TARGET repo, rebases conflicted translation PRs when a sibling PR is merged
 
-**Current Version**: v0.17.0 | **Tests**: 1,100+ (43 suites; exact count in CI) | **Glossary**: 357 terms (zh-cn, fa, fr)
+**Current Version**: v0.18.0 | **Tests**: 1,140+ (47 suites; exact count in CI) | **Glossary**: 357 terms (zh-cn, fa, fr)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-18
+
 ### Changed
 - **Node 24 runtime, declared and built for** (#89): GitHub has been force-running the action on Node 24 while `action.yml` still declared `node20` — the declared and actual runtimes had diverged. Now aligned everywhere: `action.yml` (`using: node24`), CI (`node-version: 24`), the esbuild bundle target, `@types/node` 24, `engines.node >= 24`, and CONTRIBUTING.
 - **`@actions/core` 1.11 → 2.0.3 and `@actions/github` 6.0 → 8.0.1** — the majors that clear the last production advisories: `npm audit --omit=dev` now reports **0 vulnerabilities** (was 1 high / 2 moderate, all `undici` reaching the committed bundle through these two packages). Deliberately stopped at 2.x/8.x: the 3.x/9.x lines are ESM-only, which Jest's CJS module registry cannot load — that migration is tracked separately in #89. The new `@octokit/*` majors under `@actions/github@8` are themselves ESM-only, handled at runtime by Node ≥ 22's native `require(esm)` and in Jest by a stub (`src/test-support/actions-github-stub.ts`; tests always replace the octokit instance with a fake). Verified live: a full review-mode run with the new bundle against a real PR (inputs, pagination, content fetch, comment upsert, outputs) passed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-translation",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "action-translation",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-translation",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "type": "module",
   "description": "GitHub Action to sync and review translations across repositories",


### PR DESCRIPTION
Promotes [Unreleased] to [0.18.0] (2026-07-18) and bumps version metadata. This release delivers to target repos: the forward `--github` integrity fixes from #108 (state files + heading maps in resync PR branches, target frontmatter preservation, flag-based discovery, honest summaries, localisation-ground-truth prompt), the review-mode resync fallback (#104) and criterion-score validation (#110 / #102), and the Node 24 + `@actions/*` alignment with 0 production advisories (#111 / #89).

On merge: tag `v0.18.0` + `v0.18`, move `v0` (release-time policy since v0.16.1), publish the GitHub release. Estate pins are on v0.16.1 — bumping them is tomorrow's item (tracking issue to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
