### PR TITLE
chore: release v0.19.0

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -13,6 +13,15 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## Recently landed
 
+- **v0.19.0** (2026-07-21) — #124 closed #123: `rebase-stale-siblings` (default off) refreshes
+  non-overlapping sibling PRs during waves via update-branch — no re-translation, message-gated
+  422s. **Harness-validated pre-release** under the harness-first policy: pinned workflow to the
+  PR head, PAT token, two resync PRs, one merged → sibling refreshed and its checks re-triggered
+  (run 29799241099). The A/B that decided #125's token question ran the same day on the same
+  repo: 13 GITHUB_TOKEN-rebased heads got **zero** workflow runs; the one PAT-refreshed head got
+  its review run. Production rollout of the PAT (5 edition repos: org-secret grant + one-line
+  workflow edit each) is #125, awaiting maintainer sign-off. Harness targets aligned to
+  production shape (both now carry review+rebase on `@v0`, PAT in steady state) — #109.
 - **v0.18.1** (2026-07-21) — #121 closed #115: rebase mode ignored `resync/*` PRs, so a
   drift-recovery wave left 60+ PRs going stale with every merge. The prefix turned out to be
   enforced in **three** places, not the two the issue and the first fix assumed —

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@
 - **Review Mode**: Runs in TARGET repo, posts quality review comments on translation PRs
 - **Rebase Mode**: Runs in TARGET repo, rebases conflicted translation PRs when a sibling PR is merged
 
-**Current Version**: v0.18.1 | **Tests**: 1,146+ (48 suites; exact count in CI) | **Glossary**: 357 terms (zh-cn, fa, fr)
+**Current Version**: v0.19.0 | **Tests**: 1,153+ (49 suites; exact count in CI) | **Glossary**: 357 terms (zh-cn, fa, fr)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-21
+
+### Added
+- **`rebase-stale-siblings` input — rebase mode can refresh non-overlapping sibling PRs** (#123): rebase only acts on PRs whose files overlap the merged PR, because its job is conflict resolution. But `translate forward --github` opens one PR per lecture, and each PR's metadata lists only that lecture plus its own per-lecture state file — so two siblings from the same wave never share a path, never overlap, and were skipped forever while their bases and checks went stale. That staleness is the symptom #115 actually reported ("with 60+ open at once, every stale check has to be re-enqueued by hand"); v0.18.1 made resync PRs *visible* to rebase but the overlap gate still skipped them. With the new input enabled, a non-overlapping sibling is brought current through GitHub's update-branch endpoint — the base merged forward, nothing re-translated, zero model calls. **Off by default**: the cost scales with the wave (60 open PRs means every merge refreshes up to 59 branches and re-runs their checks), and under floating `@v0` delivery a default-on would land that on every repo unannounced. Enable it for the duration of a wave; the template carries a commented-out line. Validated end-to-end on the harness pre-release: the sibling that v0.18.1 skipped was refreshed (`0 rebased, 1 refreshed, 0 skipped, 0 errors`), with a plain merge commit and its checks re-triggered.
+- 422 responses from the update-branch endpoint are **message-gated**: GitHub uses that status for "not behind base" (benign, routine mid-wave) but also for merge conflicts and head-SHA mismatches (real problems, and a conflict is reachable for a "non-overlapping" PR because overlap is computed from metadata while branches can carry hand-pushed commits touching unlisted files). Known-benign wordings resolve as "already current"; unknown 422s throw — a loud false alarm beats a silent skip. Refresh failures are handled with refresh-specific messaging rather than the conflict-resolution advice the rebase error path posts.
+
+### Changed
+- **Documented: rebase-pushed commits get no CI under the default `GITHUB_TOKEN`** — GitHub's recursion guard means a branch rebased or refreshed with it gets its new commit but no workflow runs on the new head, verified both ways on the harness (13 force-push rebased PRs: zero runs; one PAT-refreshed PR: review workflow triggered). With required status checks that is worse than skipping — the PR goes from stale-but-green to a head with no runs, which blocks merging — and force-pushed re-translated content lands unreviewed. The action reference and the rebase template now state the constraint and point at a PAT/App token, as sync workflows already use; the estate-wide token decision is tracked in #125. Applies to all of rebase mode, not only the new input.
+- **Rebase mode is documented in the action reference** — which had described the action as operating in "two modes" for as long as rebase has existed. New mode section and inputs table.
+- The helper behind the refresh lives in a new `src/rebase-siblings.ts` rather than `index.ts`, which uses `import.meta.url` and therefore cannot be loaded by Jest's CJS registry at all — the structural reason `index.ts` has no unit coverage, and how a third hard-coded branch prefix survived the first #115 fix. New rebase logic goes in testable modules.
+
 ## [0.18.1] - 2026-07-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-translation",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "action-translation",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-translation",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "private": true,
   "type": "module",
   "description": "GitHub Action to sync and review translations across repositories",


### PR DESCRIPTION
Minor release carrying #124 (closes #123).

## What ships

**`rebase-stale-siblings`** — rebase mode can now refresh non-overlapping sibling PRs during drift-recovery waves. Off by default; the changelog entry carries the full reasoning on scope, cost, and why opt-in.

## Why minor, not patch

New input, backward compatible, and the default preserves v0.18.1 behaviour exactly. A repo that changes nothing sees nothing.

## Pre-release validation (harness-first)

Unlike v0.18.1 — which was validated on the harness *after* release — this one was validated **before**: workflow pinned to the PR head, PAT token, two `resync/*` PRs, one merged. Result ([run 29799241099](https://github.com/QuantEcon/test-translation-sync.zh-cn/actions/runs/29799241099)):

    PR #639: No overlap — refreshed against the new base.
    ♻️ Rebase complete: 0 rebased, 1 refreshed, 0 skipped, 0 errors.

Sibling refreshed with a plain merge commit, nothing re-translated, and its checks re-triggered under the PAT — the `GITHUB_TOKEN` contrast case (same repo, same day) left 13 rebased heads with zero runs.

## Release checklist

- [x] CHANGELOG `[Unreleased]` → `[0.19.0]`
- [x] `package.json` + `package-lock.json` → 0.19.0
- [x] copilot-instructions version + suite count (49)
- [x] `.dev/STATE.md` — release + #125 A/B evidence recorded
- [x] All five gates: format, typecheck, lint, 49 suites / 1,153 passing, bundle reproducible
- [ ] On merge: tag `v0.19.0`, create `v0.19`, move `v0`, publish the release

## After the tag moves

Every `@v0` repo picks this up on its next trigger. The input is inert until a workflow sets it, so the estate-visible change is nil until someone opts in mid-wave. The remaining related work is #125's production half — org-secret grants + token edits in the five edition repos — which is independent of this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)