### PR TITLE
examples: rebase job requires a same-repo head branch

### DIFF
--- a/examples/rebase-translations.yml
+++ b/examples/rebase-translations.yml
@@ -25,8 +25,13 @@ jobs:
     # Keep this in step with `isTranslationBranch` in the action's src/branch-naming.ts
     # — this `if` decides whether the job runs, that predicate decides which open PRs
     # it then rebases, so a prefix matching only one of them is a no-op run.
+    # The head-repo check is belt-and-braces: fork PRs never receive secrets, so
+    # the PAT is not exposed either way — but a merged fork PR whose branch happens
+    # to match a prefix would otherwise start this job with an empty token and fail
+    # red. Same-repo branches matching these prefixes only come from the tooling.
     if: >
       github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (startsWith(github.event.pull_request.head.ref, 'translation-sync-') ||
        startsWith(github.event.pull_request.head.ref, 'resync/'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
Copilot hardening suggestion from the estate PAT rollout ([.fr#17 comment](https://github.com/QuantEcon/lecture-python-programming.fr/pull/17)). Fork PRs never receive secrets — the PAT was not exposed — but a merged fork PR whose branch happened to match a translation prefix would start the rebase job with an empty token and fail red. The head-repo check skips it instead. Applied simultaneously to both harness targets and all five estate copies so the template and its copies stay in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)