### PR TITLE
fix(cli): forward --github PRs carry the action-translation label so review triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`forward --github` PRs now carry the `action-translation` label, so the review workflow actually triggers on them** (#131): the CLI hard-coded its label set as `action-translation-sync` + `resync`, while the deployed review workflow template gates on `action-translation` — the label the *action's* pr-creator applies. Every CLI resync PR therefore failed the filter and `Review Translations` completed as `skipped`, silently; all six PRs of the lecture-python.zh-cn post-wave drift mini-wave went unreviewed until the label was added by hand. The CLI now applies `action-translation` alongside its existing labels, keeping the template's label contract single-valued instead of widening the filter in every deployed copy.
+- **The resync-drifted tutorial no longer routes `SOURCE_ONLY` files to `forward -f`** (#131): `forward` errors with `Target file not found` for targets that don't exist — a fresh translation is `init`'s job. The drift-category table and the "New files" example now say `init -f <file>`.
+
 ## [0.20.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`forward --github` PRs now carry the `action-translation` label, so the review workflow actually triggers on them** (#131): the CLI hard-coded its label set as `action-translation-sync` + `resync`, while the deployed review workflow template gates on `action-translation` — the label the *action's* pr-creator applies. Every CLI resync PR therefore failed the filter and `Review Translations` completed as `skipped`, silently; all six PRs of the lecture-python.zh-cn post-wave drift mini-wave went unreviewed until the label was added by hand. The CLI now applies `action-translation` alongside its existing labels, keeping the template's label contract single-valued instead of widening the filter in every deployed copy.
-- **The resync-drifted tutorial no longer routes `SOURCE_ONLY` files to `forward -f`** (#131): `forward` errors with `Target file not found` for targets that don't exist — a fresh translation is `init`'s job. The drift-category table and the "New files" example now say `init -f <file>`.
+- **The resync-drifted tutorial no longer routes `SOURCE_ONLY` files to `forward -f`** (#131): `forward` errors with `Target file not found` for targets that don't exist — a fresh translation is `init`'s job. The drift-category table and the "New files" example now say `init -f <file>`, with a caution that `init` stays repo-scoped even with `-f` — it rewrites `.translate/config.yml` and re-copies non-markdown assets (`_config.yml`, `_toc.yml`) from the source, so run it on a clean tree and review the diff.
 
 ## [0.20.0] - 2026-07-21
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -266,7 +266,7 @@ npx translate forward \
   --github QuantEcon/lecture-intro.zh-cn
 ```
 
-Creates one PR per file in the target repo with branch `resync/{filename}` and labels `action-translation-sync`, `resync`.
+Creates one PR per file in the target repo with branch `resync/{filename}` and labels `action-translation`, `action-translation-sync`, `resync`. The `action-translation` label is the one the review workflow template gates on, so these PRs trigger AI review automatically.
 
 **Forward triage verdicts:**
 

--- a/docs/user/tutorials/resync-drifted.md
+++ b/docs/user/tutorials/resync-drifted.md
@@ -67,7 +67,7 @@ Sync Status: lecture-python-intro ↔ lecture-python-intro.zh-cn (zh-cn)
 |---|---|---|
 | `OUTDATED` | Source has newer commits since last sync | `forward` resync |
 | `SOURCE_AHEAD` | Source added new sections | `forward` resync |
-| `SOURCE_ONLY` | Entirely new file in source | `forward -f <file>` |
+| `SOURCE_ONLY` | Entirely new file in source | `init -f <file>` |
 | `TARGET_AHEAD` | Target has more sections than source | Investigate manually |
 
 Before resyncing, run a health check to verify the target repo is properly configured:
@@ -226,7 +226,7 @@ npx translate forward \
   --github QuantEcon/lecture-python-intro.zh-cn
 ```
 
-Each PR is created on a `resync/{filename}` branch with labels `action-translation-sync` and `resync`.
+Each PR is created on a `resync/{filename}` branch with labels `action-translation`, `action-translation-sync`, and `resync`. The `action-translation` label is what the review workflow triggers on, so resync PRs get AI review automatically. All three labels must already exist in the target repo — `gh pr create` fails if any is missing.
 
 ---
 
@@ -297,12 +297,13 @@ If any files still show as `OUTDATED`, it may be because the source changed *aga
 
 ### New files (SOURCE_ONLY)
 
-For files that exist only in the source, `forward` will translate them from scratch:
+Files that exist only in the source need a fresh translation, which is `init`'s job — `forward` resyncs an *existing* translation and errors with `Target file not found` when there is nothing to resync. Use `init -f` to translate the single new file:
 
 ```bash
-npx translate forward \
+npx translate init \
   -s ~/repos/lecture-python-intro \
   -t ~/repos/lecture-python-intro.zh-cn \
+  --target-language zh-cn \
   -f new_lecture.md
 ```
 

--- a/docs/user/tutorials/resync-drifted.md
+++ b/docs/user/tutorials/resync-drifted.md
@@ -307,6 +307,8 @@ npx translate init \
   -f new_lecture.md
 ```
 
+**Caution:** `init` is repo-scoped even with `-f`. Besides translating the one file, it rewrites `.translate/config.yml` and copies every non-markdown file from the source docs folder over the target's — including `_config.yml`, `_toc.yml`, and any localized assets, which are replaced with the English source copies. Run it on a clean working tree, review the diff before committing, and revert any overwritten localized files (e.g. `git checkout -- lectures/_config.yml lectures/_toc.yml`).
+
 ### Target-only files (TARGET_ONLY)
 
 Files that exist only in the target are usually orphans — the source file was deleted or renamed. Check git history:

--- a/src/cli/__tests__/forward-pr-creator.test.ts
+++ b/src/cli/__tests__/forward-pr-creator.test.ts
@@ -111,13 +111,15 @@ describe('buildGhArgs', () => {
     expect(args[idx + 1]).toBe('-');
   });
 
-  it('includes both labels', () => {
+  it('includes all three labels, including the review-workflow gate label', () => {
     const labelIndices = args.reduce((acc: number[], val, i) => {
       if (val === '--label') acc.push(i);
       return acc;
     }, []);
-    expect(labelIndices.length).toBe(2);
+    expect(labelIndices.length).toBe(3);
     const labels = labelIndices.map((i) => args[i + 1]);
+    // The deployed review workflow template gates on `action-translation` (#131)
+    expect(labels).toContain('action-translation');
     expect(labels).toContain('action-translation-sync');
     expect(labels).toContain('resync');
   });

--- a/src/cli/forward-pr-creator.ts
+++ b/src/cli/forward-pr-creator.ts
@@ -9,7 +9,7 @@
  * Both phases use injectable runners (GitRunner / GhRunner) for testability.
  *
  * Branch: `resync/{filename}` (e.g., `resync/cobweb`)
- * Title: `🔄 [resync] cobweb.md`
+ * Title: `[action-translation] resync: cobweb.md`
  * Labels: `action-translation`, `action-translation-sync`, `resync` —
  * `action-translation` is what the deployed review workflow template gates
  * on, so resync PRs trigger AI review like sync PRs do (#131)

--- a/src/cli/forward-pr-creator.ts
+++ b/src/cli/forward-pr-creator.ts
@@ -10,7 +10,9 @@
  *
  * Branch: `resync/{filename}` (e.g., `resync/cobweb`)
  * Title: `🔄 [resync] cobweb.md`
- * Labels: `action-translation-sync`, `resync`
+ * Labels: `action-translation`, `action-translation-sync`, `resync` —
+ * `action-translation` is what the deployed review workflow template gates
+ * on, so resync PRs trigger AI review like sync PRs do (#131)
  */
 
 import * as fs from 'fs';
@@ -523,6 +525,8 @@ export function buildGhArgs(file: string, repo: string): string[] {
     title,
     '--body-file',
     '-',
+    '--label',
+    'action-translation',
     '--label',
     'action-translation-sync',
     '--label',


### PR DESCRIPTION
Fixes #131.

## The label fix

`forward --github` hard-coded its PR labels as `action-translation-sync` + `resync` (`buildGhArgs`, src/cli/forward-pr-creator.ts), while the deployed review workflow template gates on the `action-translation` label — the one the *action's* pr-creator applies (`pr-labels` default in action.yml). Every CLI resync PR therefore failed the filter and `Review Translations` completed as `skipped`, silently. All six PRs of the lecture-python.zh-cn post-wave drift mini-wave (QuantEcon/project-translation#14) went unreviewed until the label was added by hand, which fired the `labeled` event and ran the reviews.

This takes option (a) from the issue: the CLI now applies `action-translation` alongside its existing two labels, so both write paths satisfy the deployed template and the label contract stays single-valued — no template edits needed in any edition repo.

Docs updated to match: resync-drifted tutorial and cli-reference now list all three labels, name `action-translation` as the review trigger, and note that `gh pr create` fails hard if a label is missing in the target repo (the #109 harness finding).

## The tutorial fix (also from #131)

resync-drifted.md routed `SOURCE_ONLY` files to `forward -f <file>`, but `forward` throws `Target file not found … (use 'new' translation for missing targets)` for missing targets (`resyncSingleFile`). A fresh translation is `init`'s job, and `init` supports single-file runs via `-f`. The drift-category table now says `init -f <file>` and the "New files (SOURCE_ONLY)" example is a runnable `init` invocation.

## Verification

All 50 suites / 1176 tests pass. The `buildGhArgs` label test now asserts all three labels and pins the count at 3. `dist-action/` is untouched — the CLI is not part of the action bundle, so this is CLI + docs only and needs a release to reach operators via `npx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
