### PR TITLE
dev: record the tech-debt audit boundaries and correct two STATE claims

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -79,10 +79,15 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
   with its lifecycle costs recorded (build trigger: first real human addition). Parity guard
   deliberately unchanged — the scan shows strict source/output equality is a true corpus
   invariant. **The P0 co-design gate is dissolved: #94 Phase 2 (round-trip invariant + real
-  `validateMyST`) is unblocked and next.** Also: init `-f` repo-scoped side effects filed as
+  `validateMyST`) is unblocked and next** — but the round-trip invariant as PLAN formulates it is
+  unachievable (13/78 files round-trip byte-for-byte; parity and idempotence hold 78/78), so
+  reformulate before building: see [`D-2026-07-24-tech-debt-audit-boundaries.md`](decisions/D-2026-07-24-tech-debt-audit-boundaries.md).
+  Also: init `-f` repo-scoped side effects filed as
   #134; tutorial `SOURCE_ONLY` row corrected to `init -f`.
-- **v0.20.0** (2026-07-21) — #128 closed #119 + #65: structural parity guard on every write
-  path (directive shapes byte-equal or presence-matched by class; anchors exact). Calibrated
+- **v0.20.0** (2026-07-21) — #128 closed #119 + #65: structural parity guard on the sync and
+  `forward` write paths — **not `init`**, corrected 2026-07-24 by the tech-debt audit; `init` is
+  the one unguarded model-output write path (#159)
+  (directive shapes byte-equal or presence-matched by class; anchors exact). Calibrated
   empirically: byte-equal draft over 211 real pairs → 362 false positives in 3 classes
   (contents/index titles, prf:* titles, code-cell kernel tags) → calibrated guard passes
   200/211, remainder pending-drift artifacts. Found live damage during calibration: sympy.fr

--- a/.dev/decisions/D-2026-07-24-tech-debt-audit-boundaries.md
+++ b/.dev/decisions/D-2026-07-24-tech-debt-audit-boundaries.md
@@ -36,9 +36,16 @@ edit what they *encode*.
   three behaviours down to these two. Unifying further reintroduces CWD-relative lookup in the Action.
 - **`chalk` pinned at `^4`** is load-bearing, not stale: `^4` is the last CJS release and the ts-jest
   CJS harness requires it.
-- **Inside `backward-evaluator.ts`'s dead range**, `validateCategory`, `parseSpecificChanges` and
-  `sleep` are called by the *live* whole-file path. Delete lines 37-187, 222-235, 244-335 — not 192,
-  not 169, not 236-239.
+- **Inside `backward-evaluator.ts`, delete by function name, not by line range.** Dead (per-section
+  path, safe to remove): `buildEvaluationPrompt`, `parseEvaluationResponse`, `mockEvaluationResponse`,
+  `evaluateSection` — the last has zero callers anywhere, and the other three are reachable only
+  from it. **Preserve `validateCategory`, `parseSpecificChanges`, `sleep` and `buildSectionPairsBlock`**:
+  all four sit among the dead functions but are called by the *live* whole-file path
+  (`parseFileEvaluationResponse` at `:516` and `:522`, `evaluateFile` at `:660`,
+  `buildFileEvaluationPrompt` at `:413`). `buildSectionPairsBlock` is the likeliest casualty — its
+  name suggests it belongs to the per-section cluster and it does not. The audit report's line
+  ranges for this deletion are approximate at every boundary; prefer the names above and re-derive
+  the ranges by grep at deletion time.
 - **`translateSectionResync`** (`translator.ts:230`) is a live sync-mode path, unrelated to the dead
   CLI section types. Do not sweep it into that deletion.
 

--- a/.dev/decisions/D-2026-07-24-tech-debt-audit-boundaries.md
+++ b/.dev/decisions/D-2026-07-24-tech-debt-audit-boundaries.md
@@ -1,0 +1,95 @@
+# Technical-debt audit 2026-07: the boundaries remediation must respect
+
+**Context**: A 12-dimension technical-debt audit (2026-07-23) produced 139 verified findings,
+re-validated against v0.23.0 and scheduled as issues #158–#176 under milestone 1, with a
+trigger-gated backlog in #177. Those issues carry the **actions**. This record carries the
+**non-actions** — code that is load-bearing, decisions already settled, and fixes that look
+obvious and are wrong — because that guidance otherwise existed only in a gitignored report and
+would be rediscovered, and re-proposed, by the next audit or the next agent session.
+
+**Decision**: The following are recorded as settled. Restructure how these are *reached*; do not
+edit what they *encode*.
+
+## Load-bearing
+
+- **`structural-parity.ts`** was calibrated empirically against 211 real source/target pairs; 362
+  false positives in three classes (contents/index titles, `prf:*` titles, code-cell kernel tags)
+  were tuned out. Its blind spots are deliberate and documented at `:19-25` — both sides are
+  scanned with the *same* walker, so systematic blind spots cancel. Extract the fence **walk**;
+  leave the violation classes alone.
+- **`typography.ts`** carries a nesting-aware fence stack that a flat top-level walker cannot
+  replace — it is a fifth walker on purpose. Its `RULES` **must stay a `Map`**: as a plain object,
+  `applyTypography(content, 'toString')` resolves up the prototype chain and replaces the whole
+  document with `[object Undefined]` (`:270-277`). Do not fold `RULES` or `getFontRequirements`
+  into `LanguageConfig`.
+- **`localization-rules.ts`** encodes rules produced by native-speaker review (fr, ml). Change how
+  they reach the model; do not edit their text as part of a refactor.
+- **`normalizeHeadingForMatch`** (`heading-map.ts:45`) is *not* a duplicate of `cleanHeadingText` —
+  it is deliberately different and `cleanHeadingText`'s docstring at `:56` says so. The `HeadingKey`
+  brand gets exactly **two** constructors, not one.
+- **The streamed vs non-streamed Anthropic split** is deliberate (`models.ts:30`): non-streamed CLI
+  calls stay under the SDK's own non-streaming timeout guard. Preserve it at the call site when
+  consolidating clients.
+- **The two glossary loaders differ deliberately** — the CLI adds repo-local candidates because it
+  runs inside a checkout; the Action does not, because it reaches the target repo over the API and
+  uses `glossary-path` (`docs/user/glossary.md:76-86`). v0.23.0 already collapsed four loaders with
+  three behaviours down to these two. Unifying further reintroduces CWD-relative lookup in the Action.
+- **`chalk` pinned at `^4`** is load-bearing, not stale: `^4` is the last CJS release and the ts-jest
+  CJS harness requires it.
+- **Inside `backward-evaluator.ts`'s dead range**, `validateCategory`, `parseSpecificChanges` and
+  `sleep` are called by the *live* whole-file path. Delete lines 37-187, 222-235, 244-335 — not 192,
+  not 169, not 236-239.
+- **`translateSectionResync`** (`translator.ts:230`) is a live sync-mode path, unrelated to the dead
+  CLI section types. Do not sweep it into that deletion.
+
+## Settled — do not reopen
+
+- **Label-application failure stays non-fatal** (`pr-creator.ts:236`). It was deliberately wrapped
+  and downgraded after a GitHub API race failed an otherwise-successful `fa` sync, then given a 3×
+  retry and an explicit warning. Fix the *bootstrap* instead.
+- **`--test` / `testMode` keep their names.** The public input is `test-mode` in `action.yml`
+  regardless, so an internal rename does not remove the collision. Fix the behaviour, not the name.
+- **`backward --resume` semantics are a coded choice** (`backward.ts:391`). Changing it is in scope
+  (#160) but must be CHANGELOGged as a behaviour change; do not add `--skip-errored`.
+- **Search-before-create for failure issues** is refused by [`D-2026-07-16-single-review-comment.md`](D-2026-07-16-single-review-comment.md):
+  check-then-act has no conditional-write primitive and races under this repo's concurrency.
+  Close-on-recovery only.
+- The hard architectural constraints stand: no AST parsing, section-level translation units,
+  sections matched by position/ID, only changed sections translated, subsections reconstructed from
+  `section.subsections`, `dist-action/` committed on purpose.
+
+## Plausible but wrong
+
+- **Raising `MAX_TOKENS.analysis`** does not fix the truncation — the failure is an unretryable bare
+  `Error`; type it into the retryable union instead.
+- **`NODE_OPTIONS: --enable-source-maps` in `action.yml`** cannot work: a `node24` action's `runs:`
+  block has no `env:` key. An esbuild banner also fails (it runs after the module is compiled). Only
+  a separate CJS shim works — measured.
+- **"v0.23.0 added another glossary loader"** — it removed two.
+- **A `dist-action` execution smoke test instead of splitting `index.ts`** does not substitute for
+  the seam; it exercises the bundle, not the branches.
+- **Deleting the outer retry loops and setting `maxRetries: 4` on the SDK** loses the streamed paths'
+  coverage; the predicate must be the union.
+- **Unifying the two token estimators** is explicitly counter-recommended by the finding that
+  identified them.
+- **`@swc/jest` for speed** buys nothing measurable: the suite runs in ~2.5s.
+
+## The round-trip invariant needs reformulating before Phase 2
+
+`.dev/PLAN.md`'s round-trip invariant is **unachievable as written**. Measured over the corpus:
+13/78 files round-trip byte-for-byte, while parity and idempotence hold 78/78. Building Phase 2
+against the current formulation ships a gate that fails on ~84% of a healthy corpus. Correct the
+formulation first.
+
+**Consequences**:
+
+- Remediation PRs can cite this record instead of re-deriving why a tempting change is refused.
+- The list is not exhaustive and is not a substitute for the finding detail in #158–#177; it covers
+  only what would otherwise be lost when `.dev/scratch/` is cleared.
+- Superseding entries as facts change means a new decision record, not an edit to this one. In
+  particular, the glossary-loader entry expires the moment a third consumer appears.
+
+**Refs**: milestone 1 · issues #158–#177 · audit artifacts in `.dev/scratch/tech-debt-audit-2026-07-22/`
+(gitignored; `TECH-DEBT-REPORT.md` §6 and `REFUTED-REGISTER.md` are the fuller sources) ·
+[`D-2026-07-16-single-review-comment.md`](D-2026-07-16-single-review-comment.md) ·
+[`D-2026-07-14-thinking-off-sonnet5.md`](D-2026-07-14-thinking-off-sonnet5.md)


### PR DESCRIPTION
Records the guidance from the 2026-07-23 technical-debt audit that the issues do not carry, and corrects two claims in STATE.md that the audit disproved.

## Why

The audit's 139 findings are now issues #158–#176 under [milestone 1](https://github.com/QuantEcon/action-translation/milestone/1), plus the trigger-gated backlog in #177. Those carry the **actions**, and every finding is accounted for in one of them.

They do not carry the **non-actions**. The report's "explicitly not recommended" section — load-bearing code, decisions already settled, and fixes that look obvious and are wrong — has 44 items, of which only 15 appear anywhere in the issue bodies. That content lives in `.dev/scratch/`, which is gitignored, so it disappears the moment the scratch folder is cleared. It is also the content most likely to be needed: it exists to stop a future session re-proposing ground that was already walked.

## What the record covers

**Load-bearing** — restructure how these are reached, don't edit what they encode: `structural-parity.ts`'s empirical calibration (211 pairs, 362 false positives tuned out, blind spots deliberate); `typography.ts`'s `RULES` staying a `Map` rather than an object (as an object, `applyTypography(content, 'toString')` resolves up the prototype chain and replaces the document with `[object Undefined]`); `localization-rules.ts` carrying native-speaker review output; `normalizeHeadingForMatch` not being a duplicate of `cleanHeadingText`; the deliberate streamed/non-streamed Anthropic split; the two glossary loaders differing on purpose; `chalk@^4` being required by the CJS test harness; and the exact line ranges that are safe to delete in `backward-evaluator.ts`.

**Settled — do not reopen**: label-application failure staying non-fatal, `--test`/`testMode` keeping their names, `backward --resume` semantics, and search-before-create for failure issues (already refused by `D-2026-07-16-single-review-comment.md`).

**Plausible but wrong**: raising `MAX_TOKENS.analysis` to fix truncation; `NODE_OPTIONS: --enable-source-maps` in `action.yml` (a `node24` action's `runs:` block has no `env:` key — measured, only a separate CJS shim works); a `dist-action` smoke test as a substitute for splitting `index.ts`; setting `maxRetries: 4` and deleting the outer loops; `@swc/jest` for speed on a suite that runs in 2.5s.

## The two STATE.md corrections

**v0.20.0 did not put the parity guard on "every write path".** `checkStructuralParity` has four non-test call sites — `sync-orchestrator.ts:438`, `:524`, `forward.ts:385`, `diff-checks.ts:99` — and `init` is not among them. `init` is the bulk-seed path that writes an entire new language edition, so it is the one place where the guard's absence is most expensive. Tracked as #159, whose fix is four lines.

**#94 Phase 2's round-trip invariant is unachievable as PLAN formulates it.** Measured over the corpus: 13/78 files round-trip byte-for-byte, while parity and idempotence hold 78/78. STATE currently says Phase 2 is "unblocked and next" — building it against the current formulation would ship a gate that fails on ~84% of a healthy corpus. The formulation needs correcting first; this PR adds that pointer rather than changing the roadmap.

## Notes

`.dev/`-only change, so CI is skipped by the `paths-ignore` filter. No source, no `dist-action/` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
