### PR TITLE
test: type-check the suite, fix ESLint scoping, and make smoke tests fail on stale builds (#158)

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -1,4 +1,4 @@
-verified: 2026-07-23
+verified: 2026-07-24
 
 # STATE
 
@@ -7,6 +7,10 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## In flight
 
+- **Tech-debt Wave 1** (#158–#168, milestone 1) — PR A (#158, guardrails: test suite
+  type-checked, smoke-test freshness, `.dev` reference checker) opened first and alone per
+  the wave plan; B–K follow. Boundaries the wave must respect:
+  [`D-2026-07-24-tech-debt-audit-boundaries.md`](decisions/D-2026-07-24-tech-debt-audit-boundaries.md).
 - **PR #71** — Malayalam (`ml`) draft; awaiting native-reviewer calibration batch.
   Glossary PR **#69** (ja) open, awaiting native review + a `LANGUAGE_CONFIGS` entry.
 
@@ -175,8 +179,8 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 
 ## Health & context
 
-- `main` green; 1,143 tests (47 suites), lint covers all files
-  (`--max-warnings 0`) and CI checks formatting.
+- `main` green; 1,303 tests (55 suites, type-checked as of #158), lint covers all files
+  including the root `*.mjs` scripts (`--max-warnings 0`) and CI checks formatting.
 - Highest-priority known bug: issue **#65** — translator drops `(label)=` anchors
   (PLAN Phase 2), plus the silent-data-loss family documented in REVIEW §6.1.
 - Prod dep advisories: **0** (cleared by #111's `@actions/*` CJS majors; the ESM-only

--- a/.dev/log/2026-07-24-pr-a-guardrails.md
+++ b/.dev/log/2026-07-24-pr-a-guardrails.md
@@ -1,0 +1,26 @@
+# 2026-07-24 — #158 (PR A): type-check the test suite + guardrails
+
+Wave 1 opener of the tech-debt remediation. `isolatedModules: false` in the ts-jest inline
+override only (root tsconfig keeps `true` for esbuild), which puts full diagnostics on 55
+test files that were previously compiled by nothing. Plus `"root": true` for worktree lint,
+lint/format widened to the root `*.mjs` scripts, smoke tests fail on a stale
+`dist/cli/index.js` (mtime vs newest non-test file under `src/`), and the new
+`check-dev-refs.mjs` CI step that fails when a `.dev/` `path:line` reference points at a
+missing file or past end-of-file (the #179 failure shape; all 130 current refs resolve).
+
+**Discrepancy vs the issue**: enabling diagnostics surfaced **four** errors, not the
+predicted three. The fourth is in a *production* file — `commands/review.ts`'s lazy
+`import('ink')` fails type resolution under the test override's node10 resolution, because
+ink v4 is ESM-only with an `exports`-only package. ts-jest checks every file the transform
+touches, not just tests; the audit's whole-program tsc measurement counted only test-file
+errors. Fixed with a test-scoped `paths` mapping in the same jest.config.js override — no
+source change, runtime untouched (tests never execute the ink path). Reported in the PR.
+
+Two measurement corrections for the wave notes: the expected "large mechanical format diff"
+does not exist (src/ was already prettier-clean; only `build-action.mjs` reformats), and the
+suite cost of full type-checking is ~2.5s → ~8s wall.
+
+Verified before opening the PR: 55/55 suites green (1300 passed, 3 skipped), lint and
+format:check clean, zero `dist-action/` drift, freshness guard demonstrated failing on a
+touched source file and passing after rebuild, checker self-test demonstrated on both
+failure modes (missing file, line past EOF).

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,15 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended"
   ],
+  "env": {
+    "node": true
+  },
   "parserOptions": {
-    "ecmaVersion": 2020,
+    "ecmaVersion": 2022,
     "sourceType": "module"
   },
   "rules": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Format check
         run: npm run format:check
 
+      # Source changes are what invalidate .dev/ path:line references, so this
+      # runs on the normal CI trigger; .dev-only PRs still skip CI entirely.
+      - name: Check .dev references
+        run: npm run check-dev-refs
+
       - name: Build
         run: npm run build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The test suite is now type-checked** (#158): `tsconfig.json` excludes `**/*.test.ts`, ESLint is not type-aware, and the root config's `isolatedModules: true` put ts-jest in transpile-only mode — so 55 test files (~25,000 LOC) were compiled by nothing and a type error in a test was invisible until someone read it. The ts-jest override in `jest.config.js` now sets `isolatedModules: false` (the root tsconfig keeps `true`; esbuild's file-by-file compile depends on it), which surfaced four latent errors, all fixed: a dead `estimate` option in `backward.test.ts` (the field no longer exists on `BackwardOptions`), two loose accesses in `review-verdict.test.ts`, and — in a production file — `review.ts`'s lazy `import('ink')` failing type resolution under the CJS test config, because ink v4 is ESM-only with an `exports`-only package invisible to node10 resolution (fixed with a test-scoped `paths` mapping; no source change). The audit predicted three errors, all in test files; the fourth exists because ts-jest checks every file the transform touches, not just tests.
+- **CLI smoke tests fail on a stale build instead of validating it** (#158): the guard checked only that `dist/cli/index.js` *exists*, so the 11 smoke tests exercised whatever the last build left behind. It now also fails, with a `run npm run build` message, when any non-test file under `src/` is newer than the binary.
+- **`npm run lint` works in git worktrees, and the build script is inside lint/format** (#158): `.eslintrc.json` gains `"root": true` (without it, ESLint kept walking up past the repo in a worktree), and the `lint`/`format`/`format:check` globs widen from `src/**` to include the root `*.mjs` scripts — `build-action.mjs`, which produces the shipped bundle, was outside both.
+
+### Added
+- **CI checks that `path:line` references in `.dev/` notes still resolve** (#158, after #179 shipped a decision record whose line ranges were wrong at every boundary and nothing caught it): `npm run check-dev-refs` scans `.dev/**/*.md` for `path:line` / `path:line-line` references and fails if the file does not exist or the line is past end-of-file — drift and typos, not meaning. It runs as a CI step on the normal trigger: source changes are what invalidate the references, so `.dev`-only PRs still skip CI entirely.
+
 ## [0.23.0] - 2026-07-23
 
 ### Changed

--- a/build-action.mjs
+++ b/build-action.mjs
@@ -46,7 +46,7 @@ for (const file of fs.readdirSync('glossary')) {
 // dist-action/*.js as CommonJS (required for GitHub Actions runner)
 fs.writeFileSync(
   path.join(outdir, 'package.json'),
-  JSON.stringify({ type: 'commonjs' }, null, 2) + '\n',
+  JSON.stringify({ type: 'commonjs' }, null, 2) + '\n'
 );
 
 console.log(`✓ Action bundled to ${outdir}/index.js (CJS, node24)`);

--- a/check-dev-refs.mjs
+++ b/check-dev-refs.mjs
@@ -18,8 +18,10 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
+// Leading `./`/`../` and dotfile names (`.eslintrc.json`) are part of the path —
+// without them the match starts mid-name and reports a mangled reference.
 const REF_PATTERN =
-  /(?<ref>[A-Za-z0-9_@][A-Za-z0-9_./-]*\.(?:ts|tsx|js|mjs|cjs|json|ya?ml|md)):(?<start>\d+)(?:-(?<end>\d+))?/g;
+  /(?<ref>(?:\.{1,2}\/)?\.?[A-Za-z0-9_@][A-Za-z0-9_./-]*\.(?:ts|tsx|js|mjs|cjs|json|ya?ml|md)):(?<start>\d+)(?:-(?<end>\d+))?/g;
 
 const trackedFiles = execSync('git ls-files', { encoding: 'utf8' }).split('\n').filter(Boolean);
 
@@ -50,9 +52,7 @@ for (const mdFile of findMarkdownFiles('.dev')) {
       const { ref, start, end } = match.groups;
       const lastLine = Number(end ?? start);
       const candidates = ref.includes('/')
-        ? fs.existsSync(ref)
-          ? [ref]
-          : []
+        ? [ref, path.join(path.dirname(mdFile), ref)].filter((f) => fs.existsSync(f))
         : trackedFiles.filter((f) => path.basename(f) === ref);
       checked++;
 

--- a/check-dev-refs.mjs
+++ b/check-dev-refs.mjs
@@ -1,0 +1,78 @@
+/**
+ * Check that `path:line` references in .dev/ notes still resolve.
+ *
+ * Scans .dev/**\/*.md (excluding gitignored .dev/scratch/) for references of
+ * the form `path/to/file.ext:12` or `file.ext:12-18`. A reference fails if the
+ * file does not exist, or if the referenced line (range end) is past its end.
+ * Bare basenames (`heading-map.ts:45`) resolve against git-tracked files.
+ *
+ * This cannot verify a reference still points at the *right* code — only that
+ * it points at code that exists. It catches drift and typos, which is what a
+ * decision record actually shipped once (#179, then #158).
+ *
+ * Runs in CI on source changes: what invalidates a .dev reference is source
+ * moving underneath it, so .dev-only PRs (which skip CI) never need it.
+ */
+
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REF_PATTERN =
+  /(?<ref>[A-Za-z0-9_@][A-Za-z0-9_./-]*\.(?:ts|tsx|js|mjs|cjs|json|ya?ml|md)):(?<start>\d+)(?:-(?<end>\d+))?/g;
+
+const trackedFiles = execSync('git ls-files', { encoding: 'utf8' }).split('\n').filter(Boolean);
+
+function findMarkdownFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (full !== path.join('.dev', 'scratch')) results.push(...findMarkdownFiles(full));
+    } else if (entry.name.endsWith('.md')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function lineCount(file) {
+  return fs.readFileSync(file, 'utf8').split('\n').length;
+}
+
+const failures = [];
+let checked = 0;
+
+for (const mdFile of findMarkdownFiles('.dev')) {
+  const lines = fs.readFileSync(mdFile, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    for (const match of line.matchAll(REF_PATTERN)) {
+      const { ref, start, end } = match.groups;
+      const lastLine = Number(end ?? start);
+      const candidates = ref.includes('/')
+        ? fs.existsSync(ref)
+          ? [ref]
+          : []
+        : trackedFiles.filter((f) => path.basename(f) === ref);
+      checked++;
+
+      const where = `${mdFile}:${i + 1}`;
+      if (candidates.length === 0) {
+        failures.push(`${where} — \`${ref}:${start}\` — no such file`);
+      } else if (!candidates.some((f) => lineCount(f) >= lastLine)) {
+        failures.push(
+          `${where} — \`${match[0]}\` — line ${lastLine} is past end-of-file (${candidates
+            .map((f) => `${f}: ${lineCount(f)} lines`)
+            .join(', ')})`
+        );
+      }
+    }
+  });
+}
+
+if (failures.length > 0) {
+  console.error(`✗ ${failures.length} stale reference(s) in .dev/ — update the note or the code:`);
+  for (const failure of failures) console.error(`  ${failure}`);
+  process.exit(1);
+}
+console.log(`✓ ${checked} .dev/ file references resolve`);

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,16 @@ export default {
           module: 'commonjs',
           moduleResolution: 'node',
           jsx: 'react-jsx',
+          // The root tsconfig sets isolatedModules: true for esbuild's file-by-file
+          // compile; ts-jest reads it as "transpile only" and skips type-checking
+          // the whole test suite. Force full diagnostics here — tests only.
+          isolatedModules: false,
+          // ink v4 is ESM-only with an exports-only package.json, invisible to the
+          // node10 resolution this CJS override pins. Point type resolution at its
+          // real types; runtime is unaffected (tests never execute the ink path).
+          paths: {
+            ink: ['./node_modules/ink/build/index.d.ts'],
+          },
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "build": "tsc && node build-action.mjs",
     "build:cli": "tsc",
     "test": "jest",
-    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings 0",
-    "format": "prettier --write \"src/**/*.{ts,tsx}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx}\""
+    "lint": "eslint \"src/**/*.{ts,tsx}\" \"*.mjs\" --max-warnings 0",
+    "format": "prettier --write \"src/**/*.{ts,tsx}\" \"*.mjs\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"*.mjs\"",
+    "check-dev-refs": "node check-dev-refs.mjs"
   },
   "keywords": [
     "github-action",

--- a/src/__tests__/review-verdict.test.ts
+++ b/src/__tests__/review-verdict.test.ts
@@ -619,7 +619,7 @@ describe('reviewPR verdict block emission', () => {
     expect(result.recommendationReasons.join()).not.toContain('diff check failed');
 
     const parsed = parseReviewVerdict(captured.comment!);
-    expect(parsed!.diffCheckSources.positionCorrect).toBe('model');
+    expect(parsed!.diffCheckSources!.positionCorrect).toBe('model');
     const finding = parsed!.findings.find((f) => f.category === 'diff-check');
     expect(finding).toBeDefined();
     expect(finding!.description).toContain('positionCorrect');
@@ -917,7 +917,7 @@ describe('parse and normalise survive arbitrary junk', () => {
     const OPTIONAL = ['wouldAutoMerge', 'diffCheckSources'];
     for (const key of Object.keys(complete)) {
       if (OPTIONAL.includes(key)) continue;
-      const partial = { ...(complete as Record<string, unknown>) };
+      const partial = { ...(complete as unknown as Record<string, unknown>) };
       delete partial[key];
       const body = `<!-- translation-review-verdict\n${JSON.stringify(partial, null, 2)}\n-->`;
       expect(parseReviewVerdict(body)).toBeUndefined();

--- a/src/cli/__tests__/backward.test.ts
+++ b/src/cli/__tests__/backward.test.ts
@@ -68,7 +68,6 @@ describe('backward command', () => {
         json: false,
         test: true,
         minConfidence: 0.6,
-        estimate: false,
         apiKey: 'test-key',
       },
     };

--- a/src/cli/__tests__/cli-smoke.test.ts
+++ b/src/cli/__tests__/cli-smoke.test.ts
@@ -17,12 +17,35 @@ import * as fs from 'fs';
 import * as os from 'os';
 
 const CLI = path.resolve(__dirname, '../../../dist/cli/index.js');
+const SRC = path.resolve(__dirname, '../../../src');
+
+/**
+ * Newest mtime under src/, skipping test files — they are excluded from the
+ * build (tsconfig excludes **\/*.test.ts), so editing them cannot stale dist/.
+ */
+function newestSourceMtime(dir: string): number {
+  let newest = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      newest = Math.max(newest, newestSourceMtime(full));
+    } else if (/\.tsx?$/.test(entry.name) && !entry.name.endsWith('.test.ts')) {
+      newest = Math.max(newest, fs.statSync(full).mtimeMs);
+    }
+  }
+  return newest;
+}
 
 beforeAll(() => {
   if (!fs.existsSync(CLI)) {
     throw new Error(
       `CLI binary not found at ${CLI}. Run \`npm run build\` before running smoke tests.`
     );
+  }
+  // A stale binary makes every test below meaningless: they would validate
+  // whatever the last build happened to leave behind, not the current source.
+  if (newestSourceMtime(SRC) > fs.statSync(CLI).mtimeMs) {
+    throw new Error(`${CLI} is older than src/. Run \`npm run build\` before running smoke tests.`);
   }
 });
 


### PR DESCRIPTION
Closes #158.

Guardrails PR A of tech-debt Wave 1. Per the wave plan this ships **first and alone**: it is the guardrail for the deletions in #166/#167/#168, so a red CI after those lands on exactly one suspect.

## Findings retired

- **F33 / F112** — `isolatedModules: false` in the ts-jest inline override at `jest.config.js` **only**; `tsconfig.json` keeps `true` (esbuild's file-by-file compile depends on it). The 55 test files (~25k LOC) are now fully type-checked on every `npm test`.
- **F109** — `"root": true` in `.eslintrc.json`, so `npm run lint` works in git worktrees.
- **F110** — `lint` / `format` / `format:check` globs widened from `src/**` to include the root `*.mjs` scripts; `build-action.mjs` (which produces the shipped bundle) is now inside both, plus one prettier pass over it.
- **F55 / F116** — `cli-smoke.test.ts` now fails, with a `run npm run build` message, when `dist/cli/index.js` is older than the newest non-test file under `src/` — the 11 smoke tests can no longer validate a stale build. Verified both directions: fails on a touched source file, passes after rebuild.
- **Added 2026-07-24 scope** — `check-dev-refs.mjs` + a CI step: scans `.dev/**/*.md` (excluding gitignored `.dev/scratch/`) for `path:line` / `path:line-line` references and fails if the file does not exist or the line is past end-of-file. Bare basenames (`heading-map.ts:45` style) resolve against git-tracked files. Triggered on source changes as specified: the step sits in the existing CI job, `paths-ignore` untouched, so a `.dev`-only PR still skips CI. All 130 current references resolve; both failure modes self-tested.

## Discrepancy from the issue, reported per the wave rules

Enabling diagnostics surfaced **four** errors, not the predicted three. The three predicted ones are exactly where the issue says (`backward.test.ts:71` dead `estimate`; `review-verdict.test.ts:622` and `:920`). The fourth is in a **production file**: `src/cli/commands/review.ts:183`'s lazy `import('ink')` fails type resolution under the test override, because ink v4 is ESM-only with an `exports`-only package that the CJS harness's pinned `moduleResolution: node` cannot see — it failed the whole `review.test.ts` suite. The audit's count likely came from a whole-program `tsc` reading, which shows this error among `import.meta` noise; ts-jest checks every file the transform touches, not just test files. Handled with a test-scoped `paths` mapping (`ink` → `node_modules/ink/build/index.d.ts`) in the same jest.config.js override: no source change, no runtime effect (tests never execute the ink path), and the real `node16` build still resolves ink normally.

Two smaller measurement corrections: the expected "large mechanical `npm run format` diff" does not exist — `src/` was already prettier-clean (CI enforces it), so only `build-action.mjs` reformats — and full type-checking costs ~2.5s → ~8s suite wall time.

## Verification

`npm run build`, `npm test` (55/55 suites, 1300 passed / 3 skipped), `npm run lint`, `npm run format:check`, `npm run check-dev-refs` all green. Zero `dist-action/` drift, matching the issue's "rebuilds: no". `.dev/`: log entry + STATE refresh included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
