### PR TITLE
fix(harness): refuse to force-push outside test-translation-sync*; narrow a false-positive guard

### DIFF
--- a/tool-test-action-on-github/test-action-on-github.sh
+++ b/tool-test-action-on-github/test-action-on-github.sh
@@ -296,7 +296,10 @@ assert_rendered_target_workflows() {   # (cwd = target clone)
         # header comment mentions `lecture-python-intro.zh-cn` without the
         # `QuantEcon/` prefix to illustrate suffix detection, so the sed
         # correctly leaves it and a blanket grep false-positives on it.
-        grep -qE "^\s*source-repo:.*lecture-python-intro" "$f" && err="$err source-repo-not-substituted"
+        # `[[:space:]]`, not `\s`: the latter is a GNU/PCRE extension rather than
+        # POSIX ERE. Both greps on this machine happen to support it, which is
+        # exactly why it would rot silently somewhere that does not.
+        grep -qE "^[[:space:]]*source-repo:.*lecture-python-intro" "$f" && err="$err source-repo-not-substituted"
         if [ "$wf" = review ]; then
             grep -q "source-repo: '$OWNER/$SOURCE_REPO'" "$f" || err="$err missing-source-repo"
         fi

--- a/tool-test-action-on-github/test-action-on-github.sh
+++ b/tool-test-action-on-github/test-action-on-github.sh
@@ -865,11 +865,21 @@ else
     echo -e "${GREEN}Created ${#scenarios[@]} test PRs in ${SOURCE_REPO}${NC}"
     echo -e "All ${TOTAL_WORKFLOWS} workflows ran ${GREEN}${ACTION_REF}${NC} (${ACTION_REF_SHA:0:7})."
     echo ""
-    echo "Test Coverage (${#scenarios[@]} scenarios):"
-    echo "  - Basic structure changes (8 tests)"
-    echo "  - Scientific content (code cells, math) (8 tests)"
-    echo "  - Document lifecycle (CRUD operations) (4 tests)"
-    echo "  - Edge cases (preamble, nesting, special chars, empty) (4 tests)"
+    echo "Test Coverage (${#scenarios[@]} scenario(s) run):"
+    _b=0; _s=0; _d=0; _e=0
+    for sc in "${scenarios[@]}"; do
+        n=$(echo "${sc%%:*}" | grep -o '^[0-9]\+' | sed 's/^0//')
+        if   [ "$n" -le 8 ];  then _b=$((_b + 1))
+        elif [ "$n" -le 16 ]; then _s=$((_s + 1))
+        elif [ "$n" -le 20 ]; then _d=$((_d + 1))
+        else                       _e=$((_e + 1))
+        fi
+    done
+    [ "$_b" -gt 0 ] && echo "  - Basic structure changes ($_b)"
+    [ "$_s" -gt 0 ] && echo "  - Scientific content, code cells and math ($_s)"
+    [ "$_d" -gt 0 ] && echo "  - Document lifecycle, CRUD ($_d)"
+    [ "$_e" -gt 0 ] && echo "  - Edge cases: preamble, nesting, special chars, empty ($_e)"
+    true
     echo ""
     echo "Next steps:"
     echo "1. Each PR has the 'test-translation' label"

--- a/tool-test-action-on-github/test-action-on-github.sh
+++ b/tool-test-action-on-github/test-action-on-github.sh
@@ -195,7 +195,28 @@ clone_or_refresh() {   # $1 = repo name
     fi
 }
 
+# Every repo this harness writes to is `test-translation-sync[.<lang>]`, so the
+# remote name is a cheap, total safety rail: refuse to force-push anywhere else.
+#
+# This is defence in depth over the cwd fix, and it catches the whole class
+# rather than the one instance. The subshell refactor briefly left Steps 3-4
+# running git in the CALLER'S checkout, where `git push -f` would have pushed
+# 26 test branches to QuantEcon/action-translation itself. A cwd bug, a bad
+# clone, or a hand-edited SOURCE_REPO all fail here instead of on GitHub.
+assert_test_remote() {   # (cwd = a clone)
+    local url
+    url="$(git remote get-url origin 2>/dev/null || echo '')"
+    case "$url" in
+        *"/$SOURCE_REPO".git|*"/$SOURCE_REPO"|*"/$SOURCE_REPO".*.git|*"/$SOURCE_REPO".*)
+            return 0 ;;
+    esac
+    echo -e "${RED}✗ refusing to force-push: origin is '$url'${NC}" >&2
+    echo -e "${RED}  Expected a $SOURCE_REPO[.<lang>] remote. Wrong directory?${NC}" >&2
+    exit 1
+}
+
 commit_and_push() {    # $1 = commit message   (cwd = a clone)
+    assert_test_remote
     git add -A
     if ! git diff --cached --quiet; then
         git commit -q -m "$1"
@@ -271,7 +292,11 @@ assert_rendered_target_workflows() {   # (cwd = target clone)
         err=""
         f=".github/workflows/$wf-translations.yml"
         grep -q "QuantEcon/action-translation@$ACTION_REF" "$f" || err="$err ref-not-substituted"
-        grep -q 'lecture-python-intro' "$f" && err="$err source-repo-not-substituted"
+        # Check the `source-repo:` VALUE, not the whole file: the template's
+        # header comment mentions `lecture-python-intro.zh-cn` without the
+        # `QuantEcon/` prefix to illustrate suffix detection, so the sed
+        # correctly leaves it and a blanket grep false-positives on it.
+        grep -qE "^\s*source-repo:.*lecture-python-intro" "$f" && err="$err source-repo-not-substituted"
         if [ "$wf" = review ]; then
             grep -q "source-repo: '$OWNER/$SOURCE_REPO'" "$f" || err="$err missing-source-repo"
         fi
@@ -748,6 +773,7 @@ for scenario in "${scenarios[@]}"; do
         git commit -m "Test: ${description}"
         
         # Push branch (force push to overwrite if exists)
+        assert_test_remote
         git push -f origin "$branch_name"
         
         # Create draft PR with label


### PR DESCRIPTION
Two harness fixes, **both found by the first real (non-dry-run) execution** of the script #206 rewrote — the write path that `--dry-run` and `npm test` never reach.

Run: `./test-action-on-github.sh --languages ml --scenarios 01` against `main` (`98e0773`).

## 1. A correct run was aborted by an over-broad guard

`assert_rendered_target_workflows` grepped the whole rendered file for `lecture-python-intro`. But the review template's header comment names `lecture-python-intro.zh-cn` **without** the `QuantEcon/` prefix, to illustrate suffix detection — so the sed correctly leaves it, and the check false-positived on a properly substituted file:

    ✗ rendered .github/workflows/review-translations.yml is wrong: source-repo-not-substituted

Narrowed to the `source-repo:` line. Verified both directions: clean on a substituted file, still flags a genuinely unsubstituted one.

## 2. Nothing verified the remote before `git push -f`

Every repo this harness writes is `test-translation-sync[.<lang>]`, so the name is a cheap and total safety rail — and there was no check at all on either of the two force-push sites.

That matters because of what #206 nearly shipped: the subshell refactor briefly left Steps 3–4 running git in the **caller's** checkout, where the scenario loop would have force-pushed 26 test branches to `QuantEcon/action-translation` itself. That instance was fixed in `c7eacfd`, but nothing stopped the *class*.

`assert_test_remote` now guards both push sites and refuses anything that is not a `test-translation-sync` remote. It catches a bad cwd, a bad clone, or a hand-edited `SOURCE_REPO` — all of which fail locally instead of on GitHub. Verified it accepts both real test clones and refuses this repo.

## What the smoke run also proved

Beyond finding the two bugs, it closed the largest unverified item from #206 — **ml completed end to end for the first time**, having failed 26/26 on every prior run with `Unsupported target language`:

| Stage | Result |
|---|---|
| Source + ml target reset, workflows rendered, force-pushed | OK |
| Test PR created (`test-translation-sync#698`) | OK |
| ml sync workflow at `@main` | **success** |
| Translation PR opened (`test-translation-sync.ml#2`) | correct labels, state file written |
| Review workflow at `@main` | **PASS** posted — accuracy 9/10, terminology 9/10 |

That is also the first execution of the review workflow at a **non-`v0` ref**, which was the headline change of #206 and previously untestable.

Gates: format, lint, 62 suites / 1,376 tests.

Related: #206, #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
