### PR TITLE
dev: record the #210 E2E confirmation and the rename gap it left

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -16,15 +16,19 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
   first-class third language and it passes 26/26. Its two seed reference translations are
   machine drafts awaiting native review (#207); the benchmark's Phase 1 (#194) is unrun.
 - **Glossary PR #69** (ja) — open, awaiting native review + a `LANGUAGE_CONFIGS` entry.
-- **#210 — merged to `main`, unreleased and UNCONFIRMED end-to-end** (#214, 2026-07-26).
-  Review mode partitions source-PR deletions out before the F40 guard, reports a deletion-only
-  PR with no model calls and an `editor` route, and gates a target deletion the source PR did
-  not make as a blocker. Non-404 target-fetch failures now fail the run (the loop's catch-all
-  is gone), so a rate-limited fetch can no longer be laundered into a translation verdict.
-  Everything is unit-tested against a mocked octokit; the `removed` status was verified against
-  the real source PR from the failed run. **The Actions path is untested** — scenarios 18
-  (deletion) and 20 (rename) have not been run since the fix. That run is owed before the next
-  release regardless, per the E2E gate in [AGENTS.md](../AGENTS.md).
+- **#210 — merged to `main` and CONFIRMED end-to-end; unreleased** (#214, 2026-07-26). Review
+  mode partitions source-PR deletions out before the F40 guard, reports a deletion-only PR with
+  no model calls and an `editor` route, and gates a target deletion the source PR did not make
+  as a blocker. Non-404 target-fetch failures now fail the run (the loop's catch-all is gone),
+  so a rate-limited fetch can no longer be laundered into a translation verdict.
+  **Verified on the Actions path** by a scoped smoke against `main` (`--languages zh-cn
+  --scenarios 18,20`, run `30187281445`): scenario 18 green, deletion-only comment posted, and
+  `API usage: 0 call(s), 0 input + 0 output tokens` — the zero-cost claim measured in
+  production, not asserted. Scenario 20 took the ordinary review path (GitHub reported
+  `renamed`, so the old path never went missing) and passed on content.
+  **That smoke left the estate scoped**: the source repo now carries only the zh-cn sync
+  workflow; fa and ml are deleted until an unscoped run restores them. The release-gate run
+  does that — do not read a missing fa/ml workflow as a regression.
 
 ## Recently landed
 

--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -21,14 +21,16 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
   no model calls and an `editor` route, and gates a target deletion the source PR did not make
   as a blocker. Non-404 target-fetch failures now fail the run (the loop's catch-all is gone),
   so a rate-limited fetch can no longer be laundered into a translation verdict.
-  **Verified on the Actions path** by a scoped smoke against `main` (`--languages zh-cn
-  --scenarios 18,20`, run `30187281445`): scenario 18 green, deletion-only comment posted, and
-  `API usage: 0 call(s), 0 input + 0 output tokens` — the zero-cost claim measured in
-  production, not asserted. Scenario 20 took the ordinary review path (GitHub reported
-  `renamed`, so the old path never went missing) and passed on content.
-  **That smoke left the estate scoped**: the source repo now carries only the zh-cn sync
-  workflow; fa and ml are deleted until an unscoped run restores them. The release-gate run
-  does that — do not read a missing fa/ml workflow as a regression.
+  **Verified on the Actions path in all three languages.** A scoped smoke first
+  (`--languages zh-cn --scenarios 18,20`, run `30187281445`), then the estate-restoring reset
+  (`--scenarios 18`, all 9 workflows @ `main`) which re-ran scenario 18 across zh-cn, fa and
+  ml: all three green, all three posting the deletion-only comment and routing to `editor`.
+  The zh-cn run measured `API usage: 0 call(s), 0 input + 0 output tokens` — the zero-cost
+  claim observed in production, not asserted from a mock with no model to call. The exact
+  matrix that was red in #210 is now green.
+  Scenario 20 took the ordinary review path (GitHub reported `renamed`, so the old path never
+  went missing), which leaves the **delete+add rename form covered by unit tests only** —
+  filed as #216.
 
 ## Recently landed
 

--- a/.dev/log/2026-07-26-210-deletion-review.md
+++ b/.dev/log/2026-07-26-210-deletion-review.md
@@ -33,6 +33,12 @@ Details in the CHANGELOG entry; decisions that outlive the PR:
 - **Resync path untouched.** `getSourceAtCommit` returns an empty `removed` set by
   construction — a commit is a state, not a diff. Deletions on the resync path (if forward
   ever produces one) remain fatal and unhandled; noted, not fixed.
+- **E2E confirmation (post-merge, scoped smoke against `main`).** Scenario 18 green in
+  zh-cn; the deletion-only comment rendered as designed and the run reported `API usage:
+  0 call(s)`. Scenario 20 came back as GitHub-reported `renamed`, so it took the ordinary
+  review path — which means **the delete+add rename form is still only unit-tested**. It is
+  reachable in production (heavy edits defeat rename detection) and no harness scenario
+  produces it. If a rename ever fails review, that is the shape to suspect.
 - **Renames need no separate fix.** The GitHub-reported `renamed` case never had the bug (new
   path exists at both heads); the delete+add form GitHub falls back to when heavy edits defeat
   rename detection is the deletion case and is covered by the same partition. Tested both.

--- a/.dev/log/2026-07-26-210-deletion-review.md
+++ b/.dev/log/2026-07-26-210-deletion-review.md
@@ -33,12 +33,19 @@ Details in the CHANGELOG entry; decisions that outlive the PR:
 - **Resync path untouched.** `getSourceAtCommit` returns an empty `removed` set by
   construction — a commit is a state, not a diff. Deletions on the resync path (if forward
   ever produces one) remain fatal and unhandled; noted, not fixed.
-- **E2E confirmation (post-merge, scoped smoke against `main`).** Scenario 18 green in
-  zh-cn; the deletion-only comment rendered as designed and the run reported `API usage:
-  0 call(s)`. Scenario 20 came back as GitHub-reported `renamed`, so it took the ordinary
-  review path — which means **the delete+add rename form is still only unit-tested**. It is
-  reachable in production (heavy edits defeat rename detection) and no harness scenario
-  produces it. If a rename ever fails review, that is the shape to suspect.
+- **E2E confirmation (post-merge, against `main`).** Scenario 18 green in **all three
+  languages** — zh-cn from the scoped smoke, then zh-cn/fa/ml again from the estate-restoring
+  reset — each posting the deletion-only comment and routing to `editor`. zh-cn measured
+  `API usage: 0 call(s)`. The exact matrix #210 reported red is green.
+- **Restoring the estate is cheap, so spend the run on something.** The reset had to happen
+  anyway (a scoped run leaves the source repo carrying only the scoped language's sync
+  workflow). Running it with `--scenarios 18` instead of `01` cost the same and bought the
+  fa/ml confirmation. There is no reset-only mode; the minimal restore is an unscoped-language
+  run with one scenario, so **always pick the scenario that answers an open question**.
+- **Scenario 20 does not test what its name suggests.** It renames with no content change, so
+  similarity is 100% and GitHub always reports `renamed` — the path that never had the bug.
+  The delete+add form is the deletion case in disguise and is unit-tested only. Filed as #216;
+  if a rename ever fails review, that is the shape to suspect.
 - **Renames need no separate fix.** The GitHub-reported `renamed` case never had the bug (new
   path exists at both heads); the delete+add form GitHub falls back to when heavy edits defeat
   rename detection is the deletion case and is covered by the same partition. Tested both.


### PR DESCRIPTION
Follow-up to #214. Project-notes only — no source, no behaviour change.

## What the runs confirmed

Two harness runs against `main` exercised the fix on the Actions path, which the unit tests cannot reach — they mock octokit, so they prove the branching logic and nothing about the bundle, the workflow wiring, or the comment actually rendering.

Scenario 18 is now green in **all three languages**, each posting the deletion-only comment and routing to `editor`. That is the exact matrix #210 reported red.

| Language | Translation PR | Review |
|---|---|---|
| zh-cn | test-translation-sync.zh-cn#699 | deletion-only, `editor` |
| fa | test-translation-sync.fa#136 | deletion-only, `editor` |
| ml | test-translation-sync.ml#30 | deletion-only, `editor` |

From [run 30187281445](https://github.com/QuantEcon/test-translation-sync.zh-cn/actions/runs/30187281445):

    Skipping lecture.md — deleted in source PR #726; there is no source content to review against
    Deletion-only PR: 1 file(s) removed, all matching deletions in source PR #726
    API usage: 0 call(s), 0 input + 0 output tokens
    ✅ Review complete: PASS → editor

That last pair is the point: "a deletion PR costs no tokens" is now **observed in production**, not asserted from a mock that never had a model to call.

## What the runs did not cover

Scenario 20 came back as a GitHub-reported `renamed` — it renames with no content change, so similarity is 100% and rename detection always fires. It therefore exercised the path that never had the bug. The **delete+add rename form remains unit-tested only**: that is what GitHub reports when heavy edits defeat similarity detection, it is the deletion case in disguise, and no harness scenario produces it. Filed as #216 rather than left as folklore.

## Estate

The first run was scoped to zh-cn, and a scoped run re-renders `.github/` from the scoped language list — so the source repo was left carrying only the zh-cn sync workflow. The second run (unscoped languages, `--scenarios 18`) restored all **9/9 workflows** across the four repos on `main`. There is no reset-only mode, so the minimal restore is a one-scenario run; using scenario 18 rather than 01 cost the same and bought the fa/ml confirmation above. That lesson is in the log entry.

## Also updated

- #198 — item 3's standing remainder "F40's partial-source-fetch and target-fetch checks in review" is now half retired. The target-fetch half landed in #214; the partial-source-fetch half is **still open** and easy to assume went with it, so the comment restates it precisely: both gates (`reviewer.ts:957` and `:1152`) test total emptiness, so a review where one of three files failed to fetch passes ungated and produces a verdict over a comparison that silently covered two documents.
- #216 — the rename coverage gap above.

## Process note

`dd1c8de` (the earlier STATE update marking #210 merged) went straight to `main` rather than through a PR. That was my error, not a deliberate exception; the content was routine but the route was not mine to choose. Left in place because this PR supersedes its content — flagging it rather than burying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)