### PR TITLE
dev(ml): the Adisankar review packet — Stages 1-3 of #228

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ docs/_build/
 # embedded clone that `git add -A` stages as a gitlink.
 test-translation-sync*/
 tool-test-action-on-github/test-translation-sync*/
+
+# Python bytecode (experiments/ carry .py analysis scripts)
+__pycache__/
+*.pyc

--- a/experiments/ml-benchmark/PACKET.md
+++ b/experiments/ml-benchmark/PACKET.md
@@ -1,0 +1,272 @@
+# Malayalam review packet — questions for Adisankar
+
+**Date**: 2026-07-28 · **Tracking**: #228 (Phase 1 of #189), folding in #207.
+
+Thank you for the strategy document and the `getting_started.md` reference translation —
+both are doing a lot of work. The reference in particular is now the yardstick every
+automated check is calibrated against, and it passes all of them.
+
+**How to answer**: every question is numbered. Reply by number, in any medium —
+"A1: yes", "A7: the second one", "C12: keep English" is perfectly sufficient. Answer
+as far as you get; the sections are ordered so a partial reply is still useful.
+
+**What we have already decided without troubling you.** Anything a script can settle,
+a script settled. Heading fidelity, glossary-term retention, casing consistency, MyST
+structure, code fences and math blocks were all checked mechanically and are correct —
+so none of them appear below. Document structure is also **not** in question: please
+don't change headings, code cells or math blocks, only prose. Two of your four
+outstanding questions from earlier this year are answered by your own translation and
+appear below only as one-line confirmations.
+
+Every question below resolves to exactly one of three outcomes: a **glossary entry**, a
+**rule change** in the tool's configuration, or **accepted-as-is with a rationale**.
+
+---
+
+## Section A — adjudications
+
+Places where your translation and the tool's differ. You are ruling "error" or
+"acceptable variant", not reading for correctness.
+
+### A1 — the big one: how far does keep-English reach into ordinary vocabulary?
+
+Your translation keeps these **32 ordinary English words** in Latin script. The tool
+renders every one of them in Malayalam:
+
+> already, best, choose, click, create, detail, efficient, example, explore, free,
+> green, here, hit, hopefully, idea, important, instruction, interact, open, popular,
+> possible, process, provide, right, select, share, similar, simple, top, try, use
+
+These are not technical terms — that is what makes the question interesting. Examples,
+your rendering first:
+
+| Your translation | The tool |
+|---|---|
+| `For example, `np.random.r` എന്ന് type ചെയ്ത് `Tab` key press ചെയ്യുക.` | `ഉദാഹരണത്തിന്, ഇവിടെ നമ്മൾ `np.random.r` type ചെയ്ത് Tab അമർത്തുന്നു` |
+| `Hopefully, നിങ്ങളുടെ default browser-ലും ഇതുപോലെ ഒരു web page തുറന്നിട്ടുണ്ടാകും.` | `നിങ്ങളുടെ default browser-ഉം ഇതുപോലെ കാണപ്പെടുന്ന ഒരു web page-മായി തുറന്നിട്ടുണ്ടാകും എന്ന് പ്രതീക്ഷിക്കുന്നു` |
+| `താഴത്തെ split-ന്റെ top right-ൽ click ചെയ്താൽ on-line help close ആകും.` | `താഴത്തെ split-ന്റെ വലതുവശത്ത് മുകളിൽ ക്ലിക്ക് ചെയ്താൽ on-line help അടയ്ക്കുന്നു.` |
+
+**A1. Is keeping ordinary English words like these in Latin script a deliberate register
+choice we should encode as a rule, or is it incidental to how you were drafting?**
+
+If deliberate, it is one configuration change rather than 32 glossary entries — which is
+why it is first. There is one word in the other direction (`box`), where you used
+Malayalam and the tool kept English.
+
+### A2–A4 — morphology: case-suffix attachment
+
+The same English root taking a different Malayalam ending in the two translations. Each
+row is one pattern across several words, so one answer settles all of them.
+
+| # | You write | The tool writes | On the roots |
+|---|---|---|---|
+| **A2** | `-ലെ` | `-യിലെ` | directory, numpy |
+| **A3** | `-ഉം` | *(no ending)* | border, file |
+| **A4** | *(no ending)* | `-മായി` | files, message, page |
+
+**A2–A4. For each: is the tool's form wrong, or an acceptable alternative?** If the
+tool's form is simply wrong, this becomes a rule we state explicitly in the prompt.
+
+### A5–A7 — morphology: single words where the case differs outright
+
+| # | Root | You write | The tool writes |
+|---|---|---|---|
+| **A5** | cursor | `cursor-ഉം` | `cursor-നൊപ്പം` |
+| **A6** | option | `option-നെ` | `option-നെക്കാൾ` |
+| **A7** | list | `list-ൽ` | `list-ന്` |
+
+**A5–A7. Same question — error or variant?** A6 in particular reads to us like a
+comparative where the source is not comparative, so we suspect it is an error.
+
+### A8 — a suspected mistranslation
+
+The source says "**hit** the `Esc` key". You keep `hit` in English. One of the tool's
+renderings uses `അടിക്കുക` — the physical *strike* sense.
+
+**A8. Is `അടിക്കുക` wrong here, and is `hit` a word to pin as keep-English?**
+
+### A9 — the light-verb construction (we think this is the single most important question)
+
+You asked us earlier whether the whole-English sentences in your draft were deliberate
+or remnants. We can now answer with a measurement, and it points at something more
+specific than "more English".
+
+Across the document, the tool is measurably more Malayalam than you are — at every level
+of the distribution, reproducibly, and **entirely in one direction**: of the paragraphs
+where the two translations differ substantially, *every single one* has the tool using
+more Malayalam. Not one goes the other way.
+
+Looking at what actually differs, one construction explains most of it. **You keep an
+English verb in Latin script and attach a Malayalam light verb** — `press ചെയ്യുക`,
+`click ചെയ്താൽ`, `close ആകും`, `check ചെയ്യാം`, `enable ആകും`. The tool replaces the
+whole thing with a native Malayalam verb — `അമർത്തുക`, `അടയ്ക്കുന്നു`,
+`പ്രവർത്തനക്ഷമമാകും`.
+
+All nine substantial divergences, yours first:
+
+| # | You | The tool |
+|---|---|---|
+| 1 | `* For example, try `np.random.randn(3)`.` *(fully English)* | `* ഉദാഹരണത്തിന്, `np.random.randn(3)` പരീക്ഷിക്കുക.` |
+| 2 | `* edit mode to command mode, hit the `Esc` key or `Ctrl-M` …` *(fully English)* | `* edit mode-ൽ നിന്ന് command mode-ലേക്ക്, `Esc` key അല്ലെങ്കിൽ `Ctrl-M` അമർത്തുക …` |
+| 3 | `The output tells us the notebook is running at `http://localhost:8888/`` *(fully English)* | `notebook `http://localhost:8888/` എന്നിടത്ത് run ചെയ്യുന്നു എന്ന് output പറയുന്നു` |
+| 4 | `Markdown code complete ചെയ്താൽ, `Shift+Enter` press ചെയ്യുക.` | `ഇനി ഇത് ഉണ്ടാക്കാൻ നമ്മൾ `Shift+Enter` അമർത്തുന്നു` |
+| 5 | `താഴത്തെ split-ന്റെ top right-ൽ click ചെയ്താൽ on-line help close ആകും.` | `താഴത്തെ split-ന്റെ വലതുവശത്ത് മുകളിൽ ക്ലിക്ക് ചെയ്താൽ on-line help അടയ്ക്കുന്നു.` |
+| 6 | `Notebook files വെറും text files മാത്രമാണ്. They are structured in JSON. They typically end with `.ipynb`.` | `Notebook files എന്നത് JSON-ൽ ഘടനാപ്പെടുത്തിയ, സാധാരണയായി `.ipynb`-യിൽ അവസാനിക്കുന്ന text files മാത്രമാണ്.` |
+| 7 | `For example, `np.random.r` എന്ന് type ചെയ്ത് `Tab` key press ചെയ്യുക.` | `ഉദാഹരണത്തിന്, ഇവിടെ നമ്മൾ `np.random.r` type ചെയ്ത് Tab അമർത്തുന്നു` |
+| 8 | `CALLSTACK (located in the right hand window) toolbar-ലെ "Next" button ഉപയോഗിച്ച് code-ന്റെ ഓരോ line-ഉം നിങ്ങൾക്ക് check ചെയ്യാം.` | `തുടർന്ന് CALLSTACK toolbar-ലെ (വലതുവശത്തെ window-ൽ സ്ഥിതി ചെയ്യുന്നത്) "Next" button-ലെ buttons ഉപയോഗിച്ച് നിങ്ങൾക്ക് code-ലൂടെ വരി വരിയായി മുന്നോട്ട് പോകാം.` |
+| 9 | `ആ bug icon-ൽ click ചെയ്താൽ Jupyter-ന്റെ debugger enable ആകും.` | `ഈ icon-ൽ ക്ലിക്ക് ചെയ്താൽ Jupyter debugger പ്രവർത്തനക്ഷമമാകും.` |
+
+**A9. Is the `<English verb> + ചെയ്യുക/ആകും` pattern the correct default for verbs
+describing software actions?** If yes, that is one rule and it likely fixes most of the
+gap in one change — which is why we would rather ask this than ask about each paragraph.
+
+**A10. Rows 1, 2 and 3 are fully English in your translation. Deliberate?** They are all
+instruction-and-keyboard text, which is a consistent enough pattern that it looks like a
+rule rather than an accident.
+
+**A11. Row 8 looks to us like an error, not a style difference** — the tool writes
+`"Next" button-ലെ buttons` ("buttons in the Next button"), and changes your "you can
+check each line" into "you can move forward line by line". Please confirm it is wrong so
+we treat it as a defect rather than a variant.
+
+**A12. Row 6: you split it into three sentences and kept two of them fully English; the
+tool merges all three into one Malayalam sentence.** Is sentence-splitting something we
+should preserve from the source, or is merging acceptable?
+
+### A13–A14 — the two one-line confirmations
+
+**A13. Headings stay fully English.** Confirmed by measurement — your translation has
+**27 of 27 headings byte-identical** to the English source, and so do all three machine
+renderings. Please just confirm this is intended, and we will stop treating it as open.
+
+**A14. Proper names stay in Latin script.** Same — your translation does this
+throughout. Confirm and we close it.
+
+### A15 — a policy violation we found, and want your view on severity
+
+The tool sometimes writes an English word out *phonetically in Malayalam letters*
+instead of leaving it in Latin. Your translation never does this — zero instances across
+every term we checked. The machine renderings do:
+
+| Written as | Should be | Occurrences |
+|---|---|---|
+| `ക്ലിക്ക്` | `click` | 6 of 6 occurrences in one rendering |
+| `ഓപ്ഷൻ` | `option` | 3 of 7 occurrences in another |
+| `സെറ്റ്` | `set` | 2 |
+
+**A15. How bad is this — a serious error, or merely awkward?** We ask because
+`option` was transliterated 3 times out of 7 and left in Latin the other 4 times *in the
+same document*, and inconsistency of that kind is the thing we are most worried about at
+scale. All three words are absent from the glossary, so pinning them should prevent it —
+which is what Section C is for.
+
+---
+
+## Section B — content-mix catalog
+
+Contexts your reference translation does not contain, so we have no ground truth for
+them. For each, the tool's current treatment is shown so you are confirming or
+correcting rather than composing from scratch.
+
+### B1–B3 — prose that introduces a display-math block
+
+| # | English source | The tool |
+|---|---|---|
+| **B1** | `Mathematically, a vector $\mathbf{v} \in \mathbb{R}^n$ can be represented as:` | `Mathematically, ഒരു vector $\mathbf{v} \in \mathbb{R}^n$ ഇങ്ങനെ represent ചെയ്യാം:` |
+| **B2** | `An eigenvector $v$ of matrix $A$ satisfies:` | `matrix $A$-യുടെ ഒരു eigenvector $v$ ഇത് satisfy ചെയ്യുന്നു:` |
+| **B3** | `The power iteration method can be used to find the dominant eigenvalue:` | `dominant eigenvalue കണ്ടെത്താൻ power iteration method ഉപയോഗിക്കാം:` |
+
+**B1–B3. Is this the right mix for maths-introducing prose?** Note B1 keeps the
+sentence-opening adverb `Mathematically,` in English — deliberate-looking, but we did
+not ask for it.
+
+### B4 — prose inside a nested `####` subsection
+
+> **EN**: `Vector space properties are fundamental in economic modeling. The closure property ensures that combinations of feasible allocations remain feasible, while the existence of inverses allows us to model debts and obligations.`
+>
+> **ML**: `economic modeling-ൽ vector space properties അടിസ്ഥാനപരമാണ്. closure property, feasible allocations-ന്റെ combinations feasible ആയി തുടരുന്നു എന്ന് ഉറപ്പാക്കുന്നു, inverses-ന്റെ നിലനിൽപ്പ് debts, obligations എന്നിവ model ചെയ്യാൻ നമ്മെ അനുവദിക്കുന്നു.`
+
+**B4. Does deeply-nested explanatory prose want the same mix as top-level prose, or
+should it read more plainly?**
+
+### B5 — exercise and hint prose
+
+> **EN**: `Starting with your solution to exercise 1, plot three simulated time series, one for each of the cases $\alpha=0$, $\alpha=0.8$ and $\alpha=0.98$.`
+>
+> **ML**: `Exercise 1-ന്റെ നിങ്ങളുടെ solution-ൽ നിന്ന് തുടങ്ങി, മൂന്ന് simulated time series plot ചെയ്യുക; $\alpha=0$, $\alpha=0.8$, $\alpha=0.98$ എന്നീ ഓരോ case-നും ഒന്ന് വീതം.`
+
+**B5. Exercise text is instructional rather than explanatory. Is this register right for
+a student reading a problem set?**
+
+### B6–B7 — Python comments inside code cells
+
+This one has an inconsistency we created ourselves, and we would rather show it than
+hide it. In one configuration the tool translates code comments; in another it leaves
+them alone. Within the translating configuration it is also not uniform:
+
+| # | English comment | The tool |
+|---|---|---|
+| **B6** | `# Create two vectors` | `# രണ്ട് vectors സൃഷ്ടിക്കുക` |
+| | `# Visualize vectors` | `# Vectors visualize ചെയ്യുക` |
+| | `# Final demand vector (in billions)` | `# Final demand vector (billions-ൽ)` |
+| **B7** | `# Sectors: Agriculture, Manufacturing, Services` | *left identical* |
+| | `# States: Employed, Unemployed` | *left identical* |
+
+**B6. Should Python comments inside code cells be translated at all for Malayalam?** A
+"no" is easy for us to implement and arguably safer, since comments sit beside code a
+student may copy.
+
+**B7. If yes, is leaving all-proper-noun comments untouched the right exception?** That
+is what happened, but nothing in the configuration asked for it.
+
+### B8 — a note on figures
+
+We had intended to ask about figure captions. It turns out **none of the 47 figures in
+the programming series has caption prose** — they carry only a scale directive. So there
+is nothing to ask, and we are recording that rather than inventing a question.
+
+---
+
+## Section C — the English-knowns checklist
+
+*(In preparation — the underlying translations are still running. This section will be a
+tick-box table: a frequency-ranked list of technical terms from the programming series
+that are **not** yet in the glossary, showing how two different models each treated the
+term, restricted to the terms where they disagreed about whether to keep it English.
+Terms both models keep in English need no ruling from you and will not appear.)*
+
+`click`, `option`, `set` and `type` from A15 will head the list.
+
+This is the cheapest section for you to answer and the most directly useful: every
+"keep English" tick becomes a glossary entry that stops the term drifting in every
+future translation.
+
+---
+
+## Section D — one forward-looking question
+
+**D1. Which 3–5 lectures from `lecture-python-programming` would you most want to review
+next?**
+
+We will translate whichever you choose and deliver them as pull requests so you can
+comment inline. Our only constraint is variety — ideally one prose-heavy, one
+economics-heavy, one maths-heavy and one code-heavy, and at least one long one, because
+term consistency only becomes visible across a long document. Beyond that the choice is
+better made by you than by us. Asking now saves a whole round trip.
+
+The full candidate list is: about_py, getting_started, python_by_example,
+python_essentials, python_oop, python_advanced_features, functions, names, numpy,
+pandas, pandas_panel, scipy, sympy, numba, jax_intro, need_for_speed,
+numpy_vs_numba_vs_jax, writing_good_code, workspace, debugging, matplotlib.
+
+---
+
+## What happens next
+
+1. Your answers become glossary entries and configuration rules — we regenerate the
+   affected documents to confirm each fix generalises rather than patching one spot.
+2. We translate your chosen lectures from D1 and deliver them as pull requests for
+   inline review.
+
+There is no deadline. A partial reply — even just Section A1 and Section D1 — moves this
+forward materially.

--- a/experiments/ml-benchmark/PACKET.md
+++ b/experiments/ml-benchmark/PACKET.md
@@ -227,19 +227,74 @@ is nothing to ask, and we are recording that rather than inventing a question.
 
 ---
 
-## Section C — the English-knowns checklist
+## Section C — which terms to pin
 
-*(In preparation — the underlying translations are still running. This section will be a
-tick-box table: a frequency-ranked list of technical terms from the programming series
-that are **not** yet in the glossary, showing how two different models each treated the
-term, restricted to the terms where they disagreed about whether to keep it English.
-Terms both models keep in English need no ruling from you and will not appear.)*
+**First, the good news, because it changes what we need from you here.** We translated
+five lectures from the programming series with two different models and extracted every
+technical term each one produced — **203 distinct terms**. Both models kept **all 203 in
+English**. Not one was rendered in Malayalam script. Only 6 of them are pinned in the
+glossary today, so the policy is holding on nearly two hundred terms it was never
+explicitly told about.
 
-`click`, `option`, `set` and `type` from A15 will head the list.
+That means we cannot bring you the list we planned. We intended to show you the terms
+where the two models *disagreed* about keeping a term English, on the theory that
+disagreement marks the terms needing a ruling. There is no disagreement to show: the two
+models differed on ten terms and every difference was singular-versus-plural (`tuple` /
+`tuples`, `coefficient` / `coefficients`) or spacing (`deadweight loss` / `dead weight
+loss`). Nothing substantive. So the question below is a different and simpler one.
 
-This is the cheapest section for you to answer and the most directly useful: every
-"keep English" tick becomes a glossary entry that stops the term drifting in every
-future translation.
+**Why pin anything, if the policy already holds?** Because it held for these 203 terms
+and failed for four others. Three of the words that came back transliterated — `click`,
+`option`, `type` from A15 — are interface verbs rather than domain terms, so they were
+never extracted as terminology and nothing was protecting them. The fourth, `set`, *is*
+in the list below. Either way none of the four is pinned, and pinning is what makes a
+term's treatment reliable rather than lucky.
+
+**C1–C20. Below are the 20 most frequent unpinned terms, all currently kept in English
+by both models. Tick any you think should be pinned so a future model cannot change its
+mind — and flag any you think should actually be *translated*.**
+
+Please don't feel obliged to work through all twenty. The top ten matter most, and blanket
+answers are genuinely useful: "all of these keep English" or "everything down to C20 is
+fine" saves you time and tells us what we need.
+
+| # | Term | Occurrences | Lectures | Keep English? |
+|---|---|--:|--:|---|
+| C1 | `array` | 45 | 2 | ☐ keep ☐ translate |
+| C2 | `method` | 40 | 3 | ☐ keep ☐ translate |
+| C3 | `class` | 30 | 1 | ☐ keep ☐ translate |
+| C4 | `broadcasting` | 20 | 1 | ☐ keep ☐ translate |
+| C5 | `cell` | 20 | 1 | ☐ keep ☐ translate |
+| C6 | `consumer` | 20 | 1 | ☐ keep ☐ translate |
+| C7 | `data` | 20 | 1 | ☐ keep ☐ translate |
+| C8 | `instance` | 20 | 1 | ☐ keep ☐ translate |
+| C9 | `data type` | 16 | 2 | ☐ keep ☐ translate |
+| C10 | `dimension` | 15 | 1 | ☐ keep ☐ translate |
+| C11 | `object` | 15 | 1 | ☐ keep ☐ translate |
+| C12 | `shape` | 15 | 1 | ☐ keep ☐ translate |
+| C13 | `wealth` | 15 | 1 | ☐ keep ☐ translate |
+| C14 | `time series` | 13 | 2 | ☐ keep ☐ translate |
+| C15 | `element-wise` | 12 | 1 | ☐ keep ☐ translate |
+| C16 | `package` | 12 | 2 | ☐ keep ☐ translate |
+| C17 | `steady state` | 12 | 1 | ☐ keep ☐ translate |
+| C18 | `code block` | 10 | 1 | ☐ keep ☐ translate |
+| C19 | `command` | 10 | 1 | ☐ keep ☐ translate |
+| C20 | `instance data` | 10 | 1 | ☐ keep ☐ translate |
+
+*(Fourteen further terms sit just below these, and would be numbered C21–C34, in descending frequency: `sequence`,
+`expression`, `indentation`, `area`, `attribute`, `index`, `market`, `polynomial`, `set`,
+`string`, `terminal`, `text editor`, `tuple`, `coefficient`. Happy to send them as a
+follow-up — we did not want the length of the table to be the reason this goes
+unanswered.)*
+
+**C35. Is there any term in these lists you would *translate* rather than keep?** That is
+the more interesting direction. Our own guesses at candidates are the economics words
+rather than the programming ones — `consumer` (C6), `wealth` (C13), `market` — where
+everyday Malayalam may have a better rendering than the English.
+
+**C36. `set` is on the follow-up list and is also one of the four words that came back
+transliterated (A15).** It is the one term where we have direct evidence of instability,
+so it is worth a specific answer even if you skip the rest.
 
 ---
 

--- a/experiments/ml-benchmark/REPORT.md
+++ b/experiments/ml-benchmark/REPORT.md
@@ -315,12 +315,39 @@ paragraph the output keeps whole (reference index 20), so everything after it wa
 off by one, and the ratio-outlier class filled with comparisons between an anchor
 line like `(install_anaconda)=` and an unrelated prose sentence — ten such items
 were queued for the packet. **A count check does not detect this**: both documents
-have exactly 156 prose paragraphs, because splits and merges offset. Replaced with
+have exactly 155 prose paragraphs, because splits and merges offset. Replaced with
 content-anchored alignment (Needleman–Wunsch over Jaccard similarity of Latin-token
-sets, which survive translation): **145 of 156 paragraphs aligned, mean similarity
-0.781**, 9 below the confidence floor and 2+2 unmatched, all reported rather than
+sets, which survive translation): **145 of 155 paragraphs aligned, mean similarity
+0.781**, 8 below the confidence floor and 2+2 unmatched, all reported rather than
 guessed. Note the earlier distributional finding is unaffected — a two-sample test
 on the two ratio populations does not depend on pairing.
+
+**Two `strip_to_prose` copies claimed parity with `ml_metrics.py` and did not strip
+YAML frontmatter** (found in Copilot's review of #231). Every QuantEcon lecture opens
+with a jupytext `---` block, so its Latin keys were counted as prose. Impact was
+measured rather than assumed: **no finding moved** — term-treatment 4, morphology 26,
+ratio-outlier 9, total 39 with the block in or out, because it is identical in both
+renderings and cancels; and `transliteration_check.py`'s output is byte-identical,
+since a YAML block contains no Malayalam and none of the 57 targeted forms. The two
+figures above are the only numbers that changed (156→155 paragraphs, 9→8 below floor).
+The headline distributions were never at risk: they were computed by importing
+`ml_metrics.strip_to_prose`, which does strip frontmatter. The latent risk was a
+masked term-treatment divergence for any word the frontmatter also uses — `python`,
+`language`, `name` — where a body-level translation would be hidden by the
+frontmatter occurrence keeping the count non-zero.
+
+**`passage_pairs.blocks()` did not recognise plain fences** (same review). It matched
+only ```` ```{directive} ````, so ```` ```python ````, `~~~` and bare fences fell
+through to the paragraph scan and their contents were extracted as prose. `FENCE_PLAIN`
+was defined in the file and never used, which is fair evidence the case was intended
+and missed. No document in this experiment triggered it — every fence in the ml corpus
+is a braced MyST directive, and closing fences were already consumed by the forward
+scan — but the harness fixture `23-special-chars-lecture.md` is 7 plain fences and 0
+directives: before the fix, **4 of its prose blocks contained live Python** including
+the fence markers; after, **0**. Plain fences now form their own `codefence` block
+kind, count toward the structural skeleton (a lost ```` ```python ```` block is a real
+defect), bound the paragraph scan, and contribute their comment lines to the
+`code-comment` situation.
 
 **A strict block-signature check cries wolf on healthy documents.** `passage_pairs.py`
 first refused to run on `python_essentials`, reporting MISALIGNED where the source had

--- a/experiments/ml-benchmark/REPORT.md
+++ b/experiments/ml-benchmark/REPORT.md
@@ -1,7 +1,7 @@
 # REPORT: Malayalam Stage 1–2 — divergence inventory and content-mix catalog
 
-**Date**: 2026-07-28 · **Status**: Stages 1 and 2 complete; Stage 3 (English-knowns
-checklist) in progress. **Tracking**: #228 (re-scoped Phase 1 of #189).
+**Date**: 2026-07-28 · **Status**: Stages 1–3 complete; packet ready to send.
+**Tracking**: #228 (re-scoped Phase 1 of #189), folding in #207.
 
 This is the internal report. The reviewer-facing artifact is `PACKET.md` — numbered
 questions only. Everything below the question cap lives here as evidence.
@@ -19,9 +19,19 @@ say, in descending order of consequence:
    ml's inverted primary risk. The effect replicates across independent runs.
 2. **The script-ratio gate cannot see it**, because it compares the output's *mean*
    against the reference's *p10–p90* interval — a point against a wide band.
-3. **Transliterations occur** — `ക്ലിക്ക്` for "click", `ഓപ്ഷൻ` for "option",
-   `സെറ്റ്` for "set" — against a policy target of zero, and they are *not* stable
-   across runs of the same model. The native reference has none.
+3. **Transliterations occur** — `click`, `option`, `set`, `type` written phonetically in
+   Malayalam script — against a policy target of zero, in 3 of 11 renderings, and *not*
+   stable across runs of the same model. The native reference has none, across 57
+   checked terms.
+
+Set against that, the strongest positive finding of the phase: across five lectures and
+two models, **203 distinct technical terms were extracted and all 203 were kept in
+English**, only 6 of them pinned. The policy generalises far beyond what it was told.
+Structure also held on all eleven renderings.
+
+The Stage 3 method did not survive contact with ml: the `glossary-review` disagreement
+filter produces zero real candidates for a keep-English language, for a structural
+reason, and this **corrects a revision I made to #228** — see finding 8.
 
 None of this is a model-selection result and none of it may be read as one; see
 [Discipline on model claims](#discipline-on-model-claims).
@@ -32,10 +42,16 @@ None of this is a model-selection result and none of it may be read as one; see
 |---|---|---|---|
 | **Native reference** | — | hand-written | Adisankar, committed byte-exact in `reference/` (#191) |
 | **Opus 5 arm** | `claude-opus-5` | `init -f`, `--localize none` | Stage 1, this run |
-| **Opus 5 seed** | `claude-opus-5` | `glossary-review` seed role | Stage 3, same document, independent run |
-| **Sonnet 5 probe** | `claude-sonnet-5` | `glossary-review` probe role | Stage 3, same document |
+| **Opus 5 seed** | `claude-opus-5` | `glossary-review` seed role | Stage 3, 5 lectures |
+| **Sonnet 5 probe** | `claude-sonnet-5` | `glossary-review` probe role | Stage 3, 5 lectures |
 
-Source: `QuantEcon/lecture-python-programming@5816589` `lectures/getting_started.md`.
+Eleven renderings in total: the Stage 1 arm plus Stage 3's 5 lectures × 2 roles. Stage 3
+covers `getting_started`, `python_by_example`, `python_essentials`, `numpy` and
+`python_oop` — chosen as the domain-dense lectures that introduce the series' core
+vocabulary, with `getting_started` included so Stages 1 and 3 share a document and the
+native reference applies to both.
+
+Source: `QuantEcon/lecture-python-programming@5816589`, `lectures/`.
 Engine: `main` at `2c3d624` (post-v0.24.0). Glossary: `glossary/ml.json` v0.1.0-draft,
 52 terms, of which **7 occur in this source** — a fact worth stating plainly, because
 "pinned-term retention 100%" is a weaker result than it sounds when the denominator is 7.
@@ -122,8 +138,8 @@ document and 0 in another. The occurrence is real; the *rate* is unknown, and n=
 establishes only that it is not deterministic. That makes frequency a `bench/`
 question (#227) and severity an Adisankar question.
 
-Widening to every rendering produced in this phase — 5 lectures, 2 models — gives a
-better base than one document:
+Widening to every rendering produced in this phase — 5 lectures × 2 models, plus the
+Stage 1 arm — gives a much better base than one document:
 
 | Lecture | Opus 5 | Sonnet 5 |
 |---|---|---|
@@ -131,18 +147,29 @@ better base than one document:
 | `getting_started` (Stage 3) | 0 | `ഓപ്ഷൻ` option ×3, `സെറ്റ്` set ×2 |
 | `python_by_example` | 0 | `ടൈപ്പ്` type ×2 |
 | `python_essentials` | 0 | 0 |
-| `numpy` | 0 | *(pending)* |
+| `numpy` | 0 | 0 |
+| `python_oop` | 0 | 0 |
 
-**Transliteration occurred in 3 of 7 completed renderings, affecting 4 distinct
-English terms: click, option, set, type. None of the four is in the 52-term
-glossary.** That is the actionable finding, and it is what makes Stage 3's checklist
-the highest-leverage artifact in the packet: pinning these terms should prevent the
-whole class.
+**Transliteration occurred in 3 of 11 renderings, affecting 4 distinct English terms:
+click, option, set, type. None of the four is in the 52-term glossary.** That is the
+actionable finding, and it is what makes Stage 3's checklist the highest-leverage
+artifact in the packet: pinning these terms should prevent the whole class.
 
-The split across models (Opus 1-of-5 renderings, Sonnet 2-of-3) is **not** reportable
-as a model property. Seven renderings with no replicates cannot support a rate, and the
-one model-level comparison available in this data points the *opposite* way from the
-over-translation measurement in finding 1. Both belong to #227.
+Two cautions on reading the table.
+
+**It is sparse, and sparse in a way that flatters.** Eight of eleven renderings are
+clean, but the three that are not include the *only* two renderings of
+`getting_started` by different models — the most UI-heavy lecture in the sample. The
+lectures with zero (`numpy`, `python_oop`, `python_essentials`) are the ones with least
+UI vocabulary to transliterate. So the clean rows are weak evidence of compliance
+rather than strong evidence of it.
+
+**The model split is not reportable as a model property.** Opus 1-of-6 renderings,
+Sonnet 2-of-5. Eleven renderings with no replicates cannot support a rate, and this
+comparison points the *opposite* way from the over-translation measurement in finding 1
+— where the two Opus runs shifted furthest from the reference and Sonnet least. Two
+metrics, opposite orderings, no replicates: exactly the situation #227 exists to
+resolve, and exactly the inference this report must not make.
 
 ### 4. Headings: the rule is confirmed, not merely plausible
 
@@ -172,7 +199,31 @@ rendering leaves comments in English. **The packet therefore shows the reviewer 
 contradictory treatments of the same construct**, and must ask about it explicitly
 rather than let him notice the inconsistency and lose confidence in the rest.
 
-### 6. Three corrections to the recorded structure of the harness seeds
+### 6. Structure held on all eleven renderings
+
+Every rendering produced in this phase is **skeleton-identical to its English source** —
+directive sequence, math fences and headings all matching, including `numpy` at 165
+structural items:
+
+| Lecture | Structural items | Opus 5 | Sonnet 5 |
+|---|--:|---|---|
+| `getting_started` | 63 | identical | identical |
+| `python_by_example` | 82 | identical | identical |
+| `python_essentials` | 152 | identical | identical |
+| `numpy` | 165 | identical | identical |
+| `python_oop` | 70 | identical | identical |
+
+Plus the Stage 1 arm, which also passed the engine's own #159 parity guard on write.
+
+Worth stating what this is and is not. It is eleven full-document translations with no
+lost, added or transposed code cell, math block or heading — a genuinely reassuring
+result for a language whose morphology attaches to text immediately adjacent to those
+constructs. It is **not** a pass rate for the #118 head-block defect class: these are
+eleven *different* documents, not replicates of one cell, and only `getting_started`
+carries the `(label)=` + `{raw} jupyter` head block that defect needs. A rate still
+requires #227.
+
+### 7. Three corrections to the recorded structure of the harness seeds
 
 Stage 2 was specified against figures that turn out to be wrong, so the catalog was
 re-sourced. All three counts are re-derivable with `scripts/passage_pairs.py`.
@@ -196,6 +247,63 @@ no question to ask. Recorded rather than invented.
 Only two content situations survive from the seeds as specified (`math-intro` ×6,
 `nested-subsection` ×2, plus `code-comment` ×10, which was not in the spec and is the
 most interesting of them — see finding 5).
+
+### 8. Stage 3: keep-English holds on 203 terms, and the disagreement mechanism does not transfer to ml
+
+Two results, one strongly positive and one that invalidates the method this stage was
+built on — including the correction I made to #228 to enable it.
+
+**The positive result is the strongest compliance evidence in the phase.** Five lectures
+× two models, with every technical term extracted from each rendering: **203 distinct
+terms, and both models kept all 203 in English.** Zero rendered in Malayalam script; the
+extractor's per-lecture notes read "kept in English" 359 times. Only 6 of the 203 are
+pinned in `glossary/ml.json`.
+
+That is a far better compliance measurement than the FAIL gate provides. Pinned-term
+retention checked 7 terms because only 7 of the glossary's 52 occur in
+`getting_started.md`; this covers 203 unpinned terms across five lectures and two models.
+The keep-English policy generalises well beyond what it was explicitly told.
+
+**The negative result: the `glossary-review` disagreement filter yields nothing for a
+keep-English language.** `compare-models.mjs` surfaced 10 candidates. Every one is a
+singular/plural variant (`tuple`/`tuples`, `coefficient`/`coefficients`,
+`scalar`/`scalars`) or a spacing variant (`deadweight loss`/`dead weight loss`) — the
+exact categories the skill's step 4 instructs you to drop. **Zero survive hand
+assessment.**
+
+The reason is structural, not a bad run. The filter measures variation in *translation
+choice*: for fr it caught the seed saying `mutable` where the probe drifted to `muable`,
+and cut 176 proposed terms to 11 real candidates. ml's policy removes translation choice
+for precisely the terms being extracted — both models keep the term in English, so the
+recorded "rendering" *is* the English term, and cross-model disagreement degenerates to
+whether each model happened to record the singular or the plural. Within-role drift was
+similarly empty: 4 items for the seed and 2 for the probe, all plural-only.
+
+**This corrects my own revision of #228.** I argued the probe run was necessary because
+the skill is emphatic that drift alone finds nothing, and that a single-arm Stage 3 would
+have no ranking axis. The first half was right — drift alone did find nothing, 4 and 2
+plural-only items. The second half was right for the wrong reason: a single arm has no
+ranking axis, but neither does a double arm, because the axis itself is empty for ml. The
+probe was worth its ~$1.50 for what it established rather than for what it was meant to
+rank: the 203-term compliance result, the `type` transliteration, and the fact that this
+mechanism should not be reached for again on a keep-English language.
+
+**What Stage 3's artifact became.** Not a disagreement-ranked list but a
+frequency-ranked confirmation list: 152 terms both models kept English, top 20 in the
+packet, asking which to pin so the treatment is guaranteed rather than incidental. The
+motivation is direct — the four terms that *were* transliterated (`click`, `option`,
+`set`, `type`) are unpinned, and three of them are interface verbs the terminology
+extractor never proposes, so no terminology-driven process would ever have protected
+them. For ml the axis with signal is "did anything get rendered in Malayalam or
+transliterated at all", which is what `transliteration_check.py` and the novel-token
+detector measure, not "which rendering wins".
+
+**One caution about LLM-derived notes.** The extraction model annotated `key` in
+`python_essentials` as "kept in English; transliterated variants also appear". There are
+**zero** occurrences of `കീ` in either rendering of that lecture — the note is a
+fabrication. It was checked because it would otherwise have entered this report as a
+fifth transliterated term. Consistent with #227's design constraint that no LLM-judged
+metric gates anything.
 
 ## Method corrections made during this run
 
@@ -238,13 +346,20 @@ packet, and those are the sharpest items. The cap is now a per-class quota (8/12
 
 ## Divergence inventory
 
-96 divergences after clustering; 30 above the question cap.
+**39** divergences after clustering and after the false-positive fix below; all 39 fit
+inside the 30-item cap once clustered, so nothing of substance was dropped.
 
 | Class | Found | In packet | Resolves to |
 |---|--:|--:|---|
-| Term treatment | 4 | 4 | glossary entry, or one config rule |
-| Morphology | 26 | 12 | rule change or accepted-as-is |
-| Ratio outlier | 53 (of 145 aligned pairs) | 10 | depends on direction |
+| Term treatment | 4 (1 cluster of 32 words + 3) | 4 | one config rule, or a glossary entry |
+| Morphology | 26 (3 clusters + 23 single-root) | 12 | rule change or accepted-as-is |
+| Ratio outlier | 9 (of 145 aligned pairs) | 9 | depends on direction |
+
+The ratio-outlier count was **53** before the band-membership trigger was removed; 44 of
+those 53 were pairs where the two renderings agreed and the paragraph merely sat in a
+distribution tail. All 9 survivors run in the same direction — more Malayalam in the
+output — with no counter-examples, which is what let the packet ask one question about a
+construction rather than nine about paragraphs.
 
 Regenerate with:
 
@@ -284,18 +399,28 @@ English. That is a candidate mistranslation rather than a style question.
 
 ## Cost
 
-| Item | Model | Cost |
-|---|---|--:|
-| Stage 1 arm, 1 lecture | `claude-opus-5` | **not reported** (see below) |
-| Stage 3, `getting_started` probe | `claude-sonnet-5` | $0.235 |
-| Stage 3, `python_by_example` probe | `claude-sonnet-5` | $0.227 |
+| Item | Model | Reported | Estimated true |
+|---|---|--:|--:|
+| Stage 1 arm, 1 lecture | `claude-opus-5` | *no cost line* | ~$0.45 |
+| Stage 3 translation, 5 lectures, seed | `claude-opus-5` | **$0.000** | ~$2.25 |
+| Stage 3 translation, 5 lectures, probe | `claude-sonnet-5` | $1.47 | $1.47 |
+| Stage 3 term extraction, seed | `claude-opus-4-8` | $0.88 | $0.88 |
+| Stage 3 term extraction, probe | `claude-opus-4-8` | $0.85 | $0.85 |
+| **Total** | | **$3.20** | **~$5.90** |
+
+The estimate lands inside the **$4–8** range the revised #228 predicted for this phase,
+and roughly double the $3.20 the tooling reports.
 
 **The cost tracker reports `$0.000` for every `claude-opus-5` call.** The model is
 absent from `VALID_MODEL_PATTERNS` in `src/models.ts` (a known staleness item in
 `.dev/FUTURE.md`) and evidently from the pricing table too, so Opus spend is
 invisible rather than merely unvalidated. Sonnet 5 measures ~$0.23/lecture; Opus 5
 list price is $5/$25 per MTok against Sonnet's $3/$15, so the true Opus figure is
-roughly $0.4–0.5/lecture. Filed separately.
+roughly $0.4–0.5/lecture. Filed as **#230**.
+
+Note `claude-opus-4-8` prices correctly, so the gap is specific to the newer ID rather
+than to Opus generally — which is what makes it a stale-table problem rather than a
+design one.
 
 ## Discipline on model claims
 
@@ -321,6 +446,7 @@ from `bench/` rather than a table like this one.
 | `scripts/divergences.py` | ranked, clustered, content-aligned divergence inventory |
 | `scripts/transliteration_check.py` | targeted + novel-token transliteration detection |
 | `scripts/passage_pairs.py` | byte-exact aligned passage extraction for the catalog |
+| `../ml-glossary-programming/data/` | Stage 3 term extractions and candidate table (gitignored; regenerate with the `glossary-review` scripts) |
 
 Scripts quote by slicing, never by retyping, so Malayalam ZWJ/ZWNJ survive — the
 hazard `reference/README.md` documents for the reference commit applies equally to

--- a/experiments/ml-benchmark/REPORT.md
+++ b/experiments/ml-benchmark/REPORT.md
@@ -1,0 +1,327 @@
+# REPORT: Malayalam Stage 1–2 — divergence inventory and content-mix catalog
+
+**Date**: 2026-07-28 · **Status**: Stages 1 and 2 complete; Stage 3 (English-knowns
+checklist) in progress. **Tracking**: #228 (re-scoped Phase 1 of #189).
+
+This is the internal report. The reviewer-facing artifact is `PACKET.md` — numbered
+questions only. Everything below the question cap lives here as evidence.
+
+## TL;DR
+
+The shipped ml config produces output that **passes every deterministic FAIL gate**
+(27/27 headings identical, no pinned term lost, no casing variants) and is
+recognisably the right shape: technical terms in Latin, Malayalam as connective
+tissue, math and MyST structure untouched. Three things that the gates did *not*
+say, in descending order of consequence:
+
+1. **Every machine rendering is systematically more Malayalam than the native
+   reference**, at every quantile — the over-translation direction #189 names as
+   ml's inverted primary risk. The effect replicates across independent runs.
+2. **The script-ratio gate cannot see it**, because it compares the output's *mean*
+   against the reference's *p10–p90* interval — a point against a wide band.
+3. **Transliterations occur** — `ക്ലിക്ക്` for "click", `ഓപ്ഷൻ` for "option",
+   `സെറ്റ്` for "set" — against a policy target of zero, and they are *not* stable
+   across runs of the same model. The native reference has none.
+
+None of this is a model-selection result and none of it may be read as one; see
+[Discipline on model claims](#discipline-on-model-claims).
+
+## What we ran
+
+| Rendering | Model | Path | Provenance |
+|---|---|---|---|
+| **Native reference** | — | hand-written | Adisankar, committed byte-exact in `reference/` (#191) |
+| **Opus 5 arm** | `claude-opus-5` | `init -f`, `--localize none` | Stage 1, this run |
+| **Opus 5 seed** | `claude-opus-5` | `glossary-review` seed role | Stage 3, same document, independent run |
+| **Sonnet 5 probe** | `claude-sonnet-5` | `glossary-review` probe role | Stage 3, same document |
+
+Source: `QuantEcon/lecture-python-programming@5816589` `lectures/getting_started.md`.
+Engine: `main` at `2c3d624` (post-v0.24.0). Glossary: `glossary/ml.json` v0.1.0-draft,
+52 terms, of which **7 occur in this source** — a fact worth stating plainly, because
+"pinned-term retention 100%" is a weaker result than it sounds when the denominator is 7.
+
+Stage 1 wall time 4.8 min, 23,212 tokens. No structural-parity failure: the
+`{raw} jupyter` head block at line 13 survived, so the `--localize none` mitigation
+held on this run. That is one observation, not a rate — see the hazard note in #228.
+
+## Findings
+
+### 1. Systematic over-translation, reproducible
+
+Per-paragraph Malayalam share of alphabetic characters, prose only (code fences and
+headings stripped, ≥12 letters per paragraph):
+
+| Rendering | n | mean | median | p10 | p25 | p75 | p90 |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| **Native reference** | 151 | 0.485 | 0.525 | 0.132 | 0.401 | 0.628 | 0.707 |
+| Opus 5 arm | 150 | 0.577 | 0.604 | 0.348 | 0.478 | 0.718 | 0.810 |
+| Opus 5 seed | 150 | 0.567 | 0.584 | 0.317 | 0.462 | 0.717 | 0.816 |
+| Sonnet 5 probe | 150 | 0.516 | 0.540 | 0.251 | 0.407 | 0.662 | 0.777 |
+
+Every machine rendering sits above the reference at **every** quantile. Against the
+reference (Mann–Whitney U, two-sided, 151 vs 150 paragraphs):
+
+| Rendering | z | p | paragraphs ≥75% ML (ref: 10) | paragraphs ≤15% ML (ref: 16) |
+|---|--:|--:|--:|--:|
+| Opus 5 arm | −4.009 | **6.1e-05** | 31 | 9 |
+| Opus 5 seed | −3.483 | **0.0005** | 29 | 9 |
+| Sonnet 5 probe | −1.020 | 0.308 | 19 | 10 |
+
+Two independent Opus 5 runs of the same document agree closely (means 0.577 and
+0.567; 31 and 29 heavily-translated paragraphs), so the shift is a reproducible
+property of the pipeline on this document rather than run noise.
+
+The **p10 column is the sharpest reading**. The reference's lowest decile sits at
+0.132 — one paragraph in ten is essentially all-English. No machine rendering gets
+below 0.251. The native speaker writes near-fully-English paragraphs; the tool
+does not. That is the concrete form of open question 2 from #71 ("whole-English
+sentences: acceptable, or draft remnants?") and it is now answerable by pointing at
+text rather than in the abstract.
+
+### 2. The script-ratio gate is structurally unable to detect finding 1
+
+`PLAN.md` describes the check as "output distribution compared against the
+reference's p10–p90 band". The implementation compares one number against an
+interval: output **mean** 0.577 against `[ref p10 − 0.05, ref p90 + 0.05]` =
+`[0.082, 0.757]`. A mean will fall inside a p10–p90 band under almost any
+distribution, so the check fires only on gross failure — a document that is nearly
+all English or nearly all Malayalam. It reported "all gates clean" on a rendering
+whose distribution differs from the reference at p = 6.1e-05.
+
+This is the metric that was supposed to catch over- and under-translation in one
+measure, and over-translation is ml's stated primary risk. Recommend it be replaced
+by a two-sample test on the paragraph-ratio distributions (candidate for Phase 3
+graduation into `diff-checks.ts`). Filed separately rather than fixed here, per
+#228's instruction to keep incidental defects out of the phase.
+
+### 3. Transliterations, against a target of zero
+
+A transliteration writes an English word phonetically in Malayalam script instead of
+leaving it in Latin — `ക്ലിക്ക്` is not a Malayalam word, it is "click" spelled in
+Malayalam letters. #189 sets the target at 0 instances.
+
+| Rendering | Transliterations | Detail |
+|---|--:|---|
+| **Native reference** | **0** | across all 57 checked terms, 353 distinct Malayalam tokens |
+| Opus 5 arm | 6 | `ക്ലിക്ക്` — **6 of 6** source occurrences of "click" |
+| Opus 5 seed | 0 | — |
+| Sonnet 5 probe | 5 | `ഓപ്ഷൻ` — 3 of 7 "option"; `സെറ്റ്` ×2 |
+
+Three things follow.
+
+**The reference having zero is the strongest empirical confirmation of the
+keep-English policy we have**, and it also establishes that the detector has no
+false positives on a known-good document.
+
+**`option` at 3 of 7 is a consistency failure inside a single document** — the same
+term kept Latin four times and transliterated three times. Consistency is the
+primary ml risk named in #70, and this is the first field instance of it.
+
+**It does not replicate.** Opus 5 produced 6 transliterations in one run of this
+document and 0 in another. The occurrence is real; the *rate* is unknown, and n=2
+establishes only that it is not deterministic. That makes frequency a `bench/`
+question (#227) and severity an Adisankar question.
+
+Widening to every rendering produced in this phase — 5 lectures, 2 models — gives a
+better base than one document:
+
+| Lecture | Opus 5 | Sonnet 5 |
+|---|---|---|
+| `getting_started` (Stage 1 arm) | `ക്ലിക്ക്` click ×6 | — |
+| `getting_started` (Stage 3) | 0 | `ഓപ്ഷൻ` option ×3, `സെറ്റ്` set ×2 |
+| `python_by_example` | 0 | `ടൈപ്പ്` type ×2 |
+| `python_essentials` | 0 | 0 |
+| `numpy` | 0 | *(pending)* |
+
+**Transliteration occurred in 3 of 7 completed renderings, affecting 4 distinct
+English terms: click, option, set, type. None of the four is in the 52-term
+glossary.** That is the actionable finding, and it is what makes Stage 3's checklist
+the highest-leverage artifact in the packet: pinning these terms should prevent the
+whole class.
+
+The split across models (Opus 1-of-5 renderings, Sonnet 2-of-3) is **not** reportable
+as a model property. Seven renderings with no replicates cannot support a rate, and the
+one model-level comparison available in this data points the *opposite* way from the
+over-translation measurement in finding 1. Both belong to #227.
+
+### 4. Headings: the rule is confirmed, not merely plausible
+
+All four documents carry **27/27 headings byte-identical to the English source** —
+the native reference plus three independent machine renderings. #71's open question
+1 ("headings stay fully English — confirm") can be put to Adisankar as a
+one-line confirmation rather than a discussion.
+
+### 5. Code comments are translated, inconsistently, and this contradicts Stage 1
+
+The harness seed `base-lecture-ml.md` was produced by `init` at v0.24.0 under
+**default** localisation, which includes `code-comments`. Result: 8 of its 10 Python
+comments are translated, 2 are kept identical.
+
+| English comment | Malayalam |
+|---|---|
+| `# Create two vectors` | `# രണ്ട് vectors സൃഷ്ടിക്കുക` |
+| `# Visualize vectors` | `# Vectors visualize ചെയ്യുക` |
+| `# Sectors: Agriculture, Manufacturing, Services` | *identical* |
+| `# States: Employed, Unemployed` | *identical* |
+| `# Final demand vector (in billions)` | `# Final demand vector (billions-ൽ)` |
+
+The two kept identical are the two that are entirely proper nouns, which is
+defensible behaviour — but nothing in the config asks for that distinction, so it is
+incidental rather than designed. Meanwhile Stage 1 runs `--localize none`, so its
+rendering leaves comments in English. **The packet therefore shows the reviewer two
+contradictory treatments of the same construct**, and must ask about it explicitly
+rather than let him notice the inconsistency and lose confidence in the rest.
+
+### 6. Three corrections to the recorded structure of the harness seeds
+
+Stage 2 was specified against figures that turn out to be wrong, so the catalog was
+re-sourced. All three counts are re-derivable with `scripts/passage_pairs.py`.
+
+**`base-lecture-ml.md` has 7 markdown headings, not 17.** Both #207 and the #194
+comment record 17. Ten of those seventeen are **Python comments inside code cells** —
+`# Create two vectors` matches a naive `^#+\s` heading pattern. The 5-directive count
+is right; the "8 display-math blocks" is 4 blocks (8 `$$` fence *lines*).
+
+**Neither seed contains a single admonition or figure.** #228's Stage 2 requires
+"admonition and exercise prose" and "figure and caption text" as content situations.
+Both are absent from both seed documents, so those situations were re-sourced from the
+Stage 3 lectures, which carry 12 admonitions and 17 exercise/solution directives —
+at no extra cost, since those translations were already being produced.
+
+**"Figure and caption text" is a vacuous situation for this corpus.** Of **47
+`{figure}` directives across the whole programming series, 0 have caption prose** —
+every one carries only `:scale:`. There is no caption text to translate, so there is
+no question to ask. Recorded rather than invented.
+
+Only two content situations survive from the seeds as specified (`math-intro` ×6,
+`nested-subsection` ×2, plus `code-comment` ×10, which was not in the spec and is the
+most interesting of them — see finding 5).
+
+## Method corrections made during this run
+
+Recorded because both were wrong in ways that would have reached the reviewer.
+
+**Paragraph pairing by index is invalid and fails silently.** The first divergence
+inventory paired reference and output paragraphs by position. The reference splits a
+paragraph the output keeps whole (reference index 20), so everything after it was
+off by one, and the ratio-outlier class filled with comparisons between an anchor
+line like `(install_anaconda)=` and an unrelated prose sentence — ten such items
+were queued for the packet. **A count check does not detect this**: both documents
+have exactly 156 prose paragraphs, because splits and merges offset. Replaced with
+content-anchored alignment (Needleman–Wunsch over Jaccard similarity of Latin-token
+sets, which survive translation): **145 of 156 paragraphs aligned, mean similarity
+0.781**, 9 below the confidence floor and 2+2 unmatched, all reported rather than
+guessed. Note the earlier distributional finding is unaffected — a two-sample test
+on the two ratio populations does not depend on pairing.
+
+**A strict block-signature check cries wolf on healthy documents.** `passage_pairs.py`
+first refused to run on `python_essentials`, reporting MISALIGNED where the source had
+a `{code-cell}` and the target a paragraph — which looks exactly like the #118/#203
+transposition class. It was not: the rendering had **one extra paragraph** (309 vs
+308 blocks) because the translator split a paragraph earlier, shifting everything by
+one. Every code cell was present and in order. Verified by comparing the *skeleton*
+only — directives, math fences and headings — which is what the engine's own parity
+guard cares about: **all six Stage 3 renderings are skeleton-identical to their
+sources.** The script now separates the two conditions, treating a skeleton mismatch
+as a structural defect and a paragraph-count difference as benign, and in the benign
+case emits only the directive-anchored situations.
+
+**Enumerating divergences is not the same as ranking them.** Raw extraction gave 38
+term-treatment rows led by `use`, `top`, `right`, `green` — thirty glossary questions
+whose real answer is a single config rule about how far keep-English extends into
+ordinary vocabulary. The inventory now clusters: 32 ordinary words collapse into one
+register question, and morphology clusters by *transformation* rather than root (the
+reference writes `-ലെ` where the output writes `-യിലെ`, on both `directory` and
+`numpy` — one rule, not two). Cap allocation also changed: #228 ranks the classes
+1-2-3, but filling 30 slots in strict class order left **zero** ratio-outliers in the
+packet, and those are the sharpest items. The cap is now a per-class quota (8/12/10).
+
+## Divergence inventory
+
+96 divergences after clustering; 30 above the question cap.
+
+| Class | Found | In packet | Resolves to |
+|---|--:|--:|---|
+| Term treatment | 4 | 4 | glossary entry, or one config rule |
+| Morphology | 26 | 12 | rule change or accepted-as-is |
+| Ratio outlier | 53 (of 145 aligned pairs) | 10 | depends on direction |
+
+Regenerate with:
+
+    python3 experiments/ml-benchmark/scripts/divergences.py \
+      --source <EN>/lectures/getting_started.md \
+      --reference experiments/ml-benchmark/reference/getting_started.md \
+      --output <ARM>/lectures/getting_started.md \
+      --glossary glossary/ml.json --cap 30 --json
+
+### The ordinary-vocabulary cluster (packet item A1)
+
+32 ordinary English words the reference keeps in Latin script and the Opus 5 arm
+renders in Malayalam: already, best, choose, click, create, detail, efficient,
+example, explore, free, green, here, hit, hopefully, idea, important, instruction,
+interact, open, popular, possible, process, provide, right, select, share, similar,
+simple, top, try, use — and one in the other direction (`box`).
+
+This is the word-level shadow of finding 1 and the single highest-yield question in
+the packet: if the answer is "yes, keep those English too", it is one
+`additionalRules` change, not 32 glossary entries.
+
+### Morphology clusters (packet items A2–A4)
+
+| Reference writes | Output writes | On roots |
+|---|---|---|
+| `-ലെ` | `-യിലെ` | directory, numpy |
+| `-ഉം` | *(absent)* | border, file |
+| *(absent)* | `-മായി` | files, message, page |
+
+Plus individually-reported single-root differences where the two renderings choose
+different cases altogether — `cursor` (`-ഉം` vs `-നൊപ്പം`), `option` (`-നെ` vs
+`-നെക്കാൾ`, a comparative that may simply be wrong), `list` (`-ൽ` vs `-ന്`).
+
+Also worth a native eye: the Opus 5 seed renders "hit the `Esc` key" with
+`അടിക്കുക` — the literal *strike* sense of "hit". The reference keeps `hit` in
+English. That is a candidate mistranslation rather than a style question.
+
+## Cost
+
+| Item | Model | Cost |
+|---|---|--:|
+| Stage 1 arm, 1 lecture | `claude-opus-5` | **not reported** (see below) |
+| Stage 3, `getting_started` probe | `claude-sonnet-5` | $0.235 |
+| Stage 3, `python_by_example` probe | `claude-sonnet-5` | $0.227 |
+
+**The cost tracker reports `$0.000` for every `claude-opus-5` call.** The model is
+absent from `VALID_MODEL_PATTERNS` in `src/models.ts` (a known staleness item in
+`.dev/FUTURE.md`) and evidently from the pricing table too, so Opus spend is
+invisible rather than merely unvalidated. Sonnet 5 measures ~$0.23/lecture; Opus 5
+list price is $5/$25 per MTok against Sonnet's $3/$15, so the true Opus figure is
+roughly $0.4–0.5/lecture. Filed separately.
+
+## Discipline on model claims
+
+This report contains three renderings by two models and it would be easy to read a
+model comparison out of it. It is not one, and #227 owns that question.
+
+What is defensible: the over-translation *direction* holds for all three renderings;
+its magnitude is reproducible across two Opus 5 runs of the same document.
+
+What is **not** defensible from this data: that Sonnet 5 is better suited to ml
+because its shift was not significant. That is one run of one document. Sonnet 5
+also produced *more* transliterations than either Opus run and showed the
+within-document consistency failure on `option`. The two metrics point in opposite
+directions, which is exactly why a per-language default needs replicate-based rates
+from `bench/` rather than a table like this one.
+
+## Artifacts
+
+| File | Contents |
+|---|---|
+| `PACKET.md` | reviewer-facing; numbered questions only |
+| `scripts/ml_metrics.py` | the shipped gate suite (#191) |
+| `scripts/divergences.py` | ranked, clustered, content-aligned divergence inventory |
+| `scripts/transliteration_check.py` | targeted + novel-token transliteration detection |
+| `scripts/passage_pairs.py` | byte-exact aligned passage extraction for the catalog |
+
+Scripts quote by slicing, never by retyping, so Malayalam ZWJ/ZWNJ survive — the
+hazard `reference/README.md` documents for the reference commit applies equally to
+anything built out of these documents.

--- a/experiments/ml-benchmark/scripts/divergences.py
+++ b/experiments/ml-benchmark/scripts/divergences.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Rank reference-vs-output divergences into a bounded adjudication list (#228 Stage 1).
+
+The reference has 151 prose paragraphs. A naive paragraph diff hands a volunteer
+reviewer 150 items and gets no reply, so this ranks divergences into the three
+classes #228 specifies and caps the result:
+
+  1. term-treatment    — a source term kept in Latin by one rendering and put into
+                         Malayalam script by the other. Highest yield: each answer
+                         is a glossary entry.
+  2. morphology        — the same English root carrying a different case-suffix or a
+                         different attachment form (hyphenated vs bare) between the
+                         two renderings. The class where a native speaker is
+                         irreplaceable.
+  3. ratio-outlier     — paragraphs whose Malayalam share sits far from the
+                         reference's own rendering of the same paragraph. Catches
+                         over- and under-translation in one measure.
+
+Everything the deterministic FAIL gates in `ml_metrics.py` already decide is
+excluded by construction — this script is only for questions a script cannot
+settle. Divergences below the cap are still emitted (with `above_cap: false`) so
+the report can carry them as evidence without putting them to the reviewer.
+
+Byte fidelity: every quoted string is sliced from the file, never reconstructed.
+Malayalam ZWJ/ZWNJ survive.
+
+Usage:
+    python3 divergences.py --source EN.md --reference REF.md --output OUT.md \
+        --glossary ../../../glossary/ml.json --cap 30 [--json]
+"""
+
+import argparse
+import json
+import re
+import statistics
+import sys
+import unicodedata
+from pathlib import Path
+
+MALAYALAM = re.compile(r"[ഀ-ൿ]")
+LATIN_WORD = re.compile(r"[A-Za-z][A-Za-z0-9_.]*(?:'[a-z]+)?")
+# an English root immediately followed by Malayalam, with or without a joiner
+MORPH = re.compile(r"([A-Za-z][A-Za-z0-9_.]*)([-‐‑]?)([ഀ-ൿ‌‍]+)")
+FENCE = re.compile(r"^\s*(`{3,}|~{3,})")
+HEADING = re.compile(r"^#{1,6}\s")
+
+STOP = set("""a an the and or but if then else for of to in on at by with from as is are was were be been
+being do does did doing have has had having this that these those it its he she they we you i not no nor
+so than too very can will just should now s t don d ll m o re ve y ain aren couldn didn doesn hadn hasn
+haven isn ma mightn mustn needn shan shouldn wasn weren won wouldn about above after again against all
+am any because before below between both by during each few further here how into itself more most
+once only other our out over own same some such through under until up what when where which while who
+whom why your also may might must shall would could there their them then they've you're we'll let lets
+one two three first second next last e.g i.e etc via per""".split())
+
+
+def strip_to_prose(text: str) -> str:
+    """Drop fenced blocks and headings — the same convention ml_metrics.py uses."""
+    out, in_fence, marker = [], False, ""
+    for line in text.split("\n"):
+        m = FENCE.match(line)
+        if m:
+            tok = m.group(1)
+            if not in_fence:
+                in_fence, marker = True, tok[0]
+            elif tok[0] == marker:
+                in_fence = False
+            continue
+        if in_fence:
+            continue
+        if HEADING.match(line):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def paragraphs(prose: str) -> list[str]:
+    return [p for p in re.split(r"\n\s*\n", prose) if p.strip()]
+
+
+def ratio(p: str) -> float | None:
+    ml = len(MALAYALAM.findall(p))
+    la = len(re.findall(r"[A-Za-z]", p))
+    return ml / (ml + la) if ml + la >= 12 else None
+
+
+def latin_terms(prose: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for w in LATIN_WORD.findall(prose):
+        lw = w.lower().rstrip(".")  # `programs.` and `programs` are one term
+        if not lw or lw in STOP or len(lw) < 3 or lw.isdigit():
+            continue
+        counts[lw] = counts.get(lw, 0) + 1
+    return counts
+
+
+def morph_forms(prose: str) -> dict[str, dict[str, int]]:
+    """Latin root -> {suffix-with-joiner: count}."""
+    res: dict[str, dict[str, int]] = {}
+    for root, joiner, suffix in MORPH.findall(prose):
+        lr = root.lower()
+        if lr in STOP or len(root) < 3:
+            continue
+        key = f"{joiner}{suffix}"
+        res.setdefault(lr, {})
+        res[lr][key] = res[lr].get(key, 0) + 1
+    return res
+
+
+def anchor_tokens(para: str) -> set[str]:
+    """Language-independent content anchors: Latin words, URLs and code spans.
+
+    A Malayalam translation of a QuantEcon paragraph keeps its technical terms,
+    library names, URLs and inline code in Latin script, so these survive
+    translation and identify the paragraph across two independent renderings.
+    """
+    toks = set()
+    for url in re.findall(r"https?://[^\s)\]]+", para):
+        toks.add(url.rstrip(".,)"))
+    for span in re.findall(r"`([^`\n]+)`", para):
+        toks.add("`" + span.strip().lower() + "`")
+    for w in LATIN_WORD.findall(para):
+        lw = w.lower().rstrip(".")
+        if lw and lw not in STOP and len(lw) >= 3:
+            toks.add(lw)
+    return toks
+
+
+def align_paragraphs(rp: list[str], op: list[str], floor: float = 0.30):
+    """Monotonic best-overlap alignment between two paragraph sequences.
+
+    Needleman-Wunsch over Jaccard similarity of anchor-token sets, with a zero
+    score for gaps. Returns (pairs, stats) where pairs is [(ref_i, out_j, sim)]
+    for matches at or above `floor`; anything weaker is left unpaired and counted,
+    because a guessed pair becomes a nonsense question in the reviewer's packet.
+    """
+    ra = [anchor_tokens(p) for p in rp]
+    oa = [anchor_tokens(p) for p in op]
+
+    def sim(i: int, j: int) -> float:
+        a, b = ra[i], oa[j]
+        if not a or not b:
+            return 0.0
+        inter = len(a & b)
+        return inter / len(a | b) if inter else 0.0
+
+    n, m = len(rp), len(op)
+    # DP table; band the search to +/-12 to keep it cheap and to forbid wild jumps
+    band = 12
+    NEG = float("-inf")
+    dp = [[NEG] * (m + 1) for _ in range(n + 1)]
+    bk = [[None] * (m + 1) for _ in range(n + 1)]
+    dp[0][0] = 0.0
+    for i in range(n + 1):
+        for j in range(m + 1):
+            if abs(i - j) > band or dp[i][j] == NEG:
+                continue
+            cur = dp[i][j]
+            if i < n and j < m:
+                s = cur + sim(i, j)
+                if s > dp[i + 1][j + 1]:
+                    dp[i + 1][j + 1], bk[i + 1][j + 1] = s, (i, j, "match")
+            if i < n and cur > dp[i + 1][j]:
+                dp[i + 1][j], bk[i + 1][j] = cur, (i, j, "gap-ref")
+            if j < m and cur > dp[i][j + 1]:
+                dp[i][j + 1], bk[i][j + 1] = cur, (i, j, "gap-out")
+
+    # walk back from the best reachable terminal cell
+    best, bi, bj = NEG, n, m
+    for i in range(n + 1):
+        for j in range(m + 1):
+            if dp[i][j] > NEG and (i == n or j == m) and dp[i][j] > best:
+                best, bi, bj = dp[i][j], i, j
+    path = []
+    i, j = bi, bj
+    while bk[i][j] is not None:
+        pi, pj, kind = bk[i][j]
+        if kind == "match":
+            path.append((pi, pj))
+        i, j = pi, pj
+    path.reverse()
+
+    pairs, weak = [], 0
+    for i, j in path:
+        s = sim(i, j)
+        if s >= floor:
+            pairs.append((i, j, s))
+        else:
+            weak += 1
+    stats = {
+        "reference_paragraphs": n,
+        "output_paragraphs": m,
+        "aligned": len(pairs),
+        "below_floor": weak,
+        "unmatched_reference": n - len(path),
+        "unmatched_output": m - len(path),
+        "floor": floor,
+        "mean_similarity": round(sum(p[2] for p in pairs) / len(pairs), 3) if pairs else 0.0,
+    }
+    return pairs, stats
+
+
+def lemma(word: str) -> str:
+    """Crude inflectional collapse so `use`/`using`/`used` form one question.
+
+    Deliberately not a real stemmer: the point is only to stop the same English
+    word producing several contradictory rows, and an aggressive stemmer would
+    merge genuinely distinct technical terms (`index`/`indices` is fine to merge,
+    `array`/`arrange` is not).
+    """
+    w = word.lower()
+    for suf in ("'s", "ing", "ies", "es", "ed", "s"):
+        if w.endswith(suf) and len(w) - len(suf) >= 4:
+            stem = w[: -len(suf)]
+            if suf == "ies":
+                return stem + "y"
+            if suf == "ing" and len(stem) > 2 and stem[-1] == stem[-2]:
+                return stem[:-1]
+            # `process` -> `proces` is not a lemma; a stem still ending in the
+            # suffix letter means the word was never inflected in the first place
+            if suf in ("s", "es") and stem.endswith("s"):
+                return w
+            return stem
+    return w
+
+
+def technical_vocabulary(raw_source: str, pinned: set[str]) -> set[str]:
+    """Terms with positive evidence of being technical rather than ordinary prose.
+
+    Signals, in the source document only (never in a translation, which would let
+    a rendering decide its own question):
+      * pinned in the glossary
+      * appears inside backticks or a fenced code block
+      * carries an internal dot or underscore (`np.array`, `sys_path`)
+      * capitalised somewhere other than sentence-initial position
+    """
+    tech = set(pinned)
+    for span in re.findall(r"`([^`\n]+)`", raw_source):
+        for w in LATIN_WORD.findall(span):
+            tech.add(w.lower())
+            tech.add(lemma(w))
+    for m in re.finditer(r"\b[A-Za-z][A-Za-z0-9]*[._][A-Za-z0-9_.]+\b", raw_source):
+        tech.add(m.group(0).lower())
+    # capitalised mid-sentence: preceded by a word character run and a space, but
+    # not immediately after a sentence terminator
+    for m in re.finditer(r"(?<![.!?]\s)(?<!^)\b([A-Z][a-z]{2,})\b", raw_source, re.M):
+        tech.add(m.group(1).lower())
+        tech.add(lemma(m.group(1)))
+    for t in list(tech):
+        tech.add(lemma(t))
+    return tech
+
+
+def contexts(prose: str, needle: str, limit: int = 2, width: int = 110) -> list[str]:
+    """Byte-exact excerpts around a needle, for evidence in the packet."""
+    out, start = [], 0
+    low, nlow = prose.lower(), needle.lower()
+    while len(out) < limit:
+        i = low.find(nlow, start)
+        if i < 0:
+            break
+        a = max(0, i - width // 2)
+        b = min(len(prose), i + len(needle) + width // 2)
+        out.append(prose[a:b].replace("\n", " ").strip())
+        start = i + len(needle)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--source", type=Path, required=True)
+    ap.add_argument("--reference", type=Path, required=True)
+    ap.add_argument("--output", type=Path, required=True)
+    ap.add_argument("--glossary", type=Path)
+    ap.add_argument("--cap", type=int, default=30)
+    ap.add_argument("--min-count", type=int, default=2,
+                    help="minimum source occurrences for a term-treatment question")
+    ap.add_argument("--delta-floor", type=float, default=0.30,
+                    help="minimum absolute difference in Malayalam share between the "
+                         "two renderings of a paragraph to raise it as a question")
+    ap.add_argument("--align-floor", type=float, default=0.30,
+                    help="minimum anchor-token Jaccard for a paragraph pair to be "
+                         "trusted; weaker pairs are counted, never questioned")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    src = strip_to_prose(args.source.read_text(encoding="utf-8"))
+    ref = strip_to_prose(args.reference.read_text(encoding="utf-8"))
+    out = strip_to_prose(args.output.read_text(encoding="utf-8"))
+
+    pinned: set[str] = set()
+    if args.glossary and args.glossary.exists():
+        g = json.loads(args.glossary.read_text(encoding="utf-8"))
+        terms = g.get("terms", g)
+        it = terms.items() if isinstance(terms, dict) else [
+            (t.get("source") or t.get("term"), t) for t in terms]
+        for k, _ in it:
+            if k:
+                pinned.add(str(k).lower())
+
+    raw_src = args.source.read_text(encoding="utf-8")
+    technical = technical_vocabulary(raw_src, pinned)
+
+    s_terms = latin_terms(src)
+    r_terms, o_terms = latin_terms(ref), latin_terms(out)
+    findings = []
+
+    # -- class 1: term treatment ---------------------------------------------
+    # Grouped by lemma first: `use`/`using`/`used` are one question, not three,
+    # and reporting them separately produced contradictory "kept by reference" /
+    # "kept by output" rows for the same word in the first version of this script.
+    groups: dict[str, dict] = {}
+    for term, n in s_terms.items():
+        if n < args.min_count:
+            continue
+        in_ref, in_out = r_terms.get(term, 0), o_terms.get(term, 0)
+        if (in_ref == 0) == (in_out == 0):
+            continue
+        lem = lemma(term)
+        g = groups.setdefault(lem, {"surface": {}, "src": 0, "ref": 0, "out": 0})
+        g["surface"][term] = n
+        g["src"] += n
+        g["ref"] += in_ref
+        g["out"] += in_out
+
+    ordinary = []
+    for lem, g in sorted(groups.items(), key=lambda kv: -kv[1]["src"]):
+        if g["ref"] == 0 and g["out"] == 0:
+            continue
+        kept = "reference" if g["ref"] > g["out"] else "output"
+        is_tech = any(s in technical for s in g["surface"]) or lem in technical
+        item = {
+            "class": "term-treatment",
+            "term": lem,
+            "surface_forms": sorted(g["surface"]),
+            "source_count": g["src"],
+            "reference_count": g["ref"],
+            "output_count": g["out"],
+            "kept_english_by": kept,
+            "translated_by": "output" if kept == "reference" else "reference",
+            "pinned": lem in pinned,
+            "technical": is_tech,
+            "resolves_to": "glossary entry",
+        }
+        if is_tech:
+            item["score"] = g["src"] * 10 + (5 if lem in pinned else 0)
+            item["reference_context"] = contexts(ref, lem)
+            item["output_context"] = contexts(out, lem)
+            findings.append(item)
+        else:
+            ordinary.append(item)
+
+    # The ordinary-vocabulary cases are one register question, not N glossary
+    # questions. Enumerating them individually is what made the first run of this
+    # script produce thirty rows about `use`, `top`, `right` and `green` — a bad
+    # use of a volunteer's afternoon, and the wrong shape of question besides:
+    # the answer is a language-config rule, not thirty glossary entries.
+    if ordinary:
+        by_ref = [o for o in ordinary if o["kept_english_by"] == "reference"]
+        by_out = [o for o in ordinary if o["kept_english_by"] == "output"]
+        findings.append({
+            "class": "term-treatment",
+            "term": "(clustered) ordinary English vocabulary",
+            "cluster": True,
+            "count": len(ordinary),
+            "kept_english_by_reference": sorted(o["term"] for o in by_ref),
+            "kept_english_by_output": sorted(o["term"] for o in by_out),
+            "score": 10_000,  # ranks first: it subsumes the largest divergence class
+            "resolves_to": "language-config rule change",
+            "members": ordinary,
+        })
+
+    # -- class 2: morphology -------------------------------------------------
+    # Clustered by the *transformation* rather than by root: if the reference
+    # writes `-ലെ` where the output writes `-യിലെ` on five different English
+    # roots, that is one rule question, not five. Idiosyncratic single-root
+    # differences stay individual — those are the ones that may be plain errors.
+    r_morph, o_morph = morph_forms(ref), morph_forms(out)
+    morph_items = []
+    for root in sorted(set(r_morph) & set(o_morph)):
+        rs, os_ = set(r_morph[root]), set(o_morph[root])
+        if rs == os_:
+            continue
+        r_join = any(k.startswith(("-", "‐", "‑")) for k in rs)
+        o_join = any(k.startswith(("-", "‐", "‑")) for k in os_)
+        morph_items.append({
+            "root": root,
+            "kind": "attachment" if r_join != o_join else "suffix",
+            "reference_forms": sorted(rs),
+            "output_forms": sorted(os_),
+            "ref_only": sorted(rs - os_),
+            "out_only": sorted(os_ - rs),
+            "reference_total": sum(r_morph[root].values()),
+            "output_total": sum(o_morph[root].values()),
+        })
+
+    sig_groups: dict[tuple, list[dict]] = {}
+    for it in morph_items:
+        sig_groups.setdefault((tuple(it["ref_only"]), tuple(it["out_only"])), []).append(it)
+
+    for (ref_only, out_only), members in sorted(
+            sig_groups.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+        if len(members) >= 2:
+            findings.append({
+                "class": "morphology",
+                "root": f"(clustered) {len(members)} roots",
+                "cluster": True,
+                "kind": members[0]["kind"],
+                "reference_only_forms": list(ref_only),
+                "output_only_forms": list(out_only),
+                "roots": sorted(m["root"] for m in members),
+                "score": 60 + 5 * len(members),
+                "reference_context": contexts(ref, members[0]["root"]),
+                "output_context": contexts(out, members[0]["root"]),
+                "resolves_to": "rule change or accepted-as-is",
+                "members": members,
+            })
+        else:
+            m = members[0]
+            findings.append({
+                "class": "morphology",
+                **m,
+                "score": (8 if m["kind"] == "attachment" else 4)
+                         + min(m["output_total"], 6),
+                "reference_context": contexts(ref, m["root"]),
+                "output_context": contexts(out, m["root"]),
+                "resolves_to": "rule change or accepted-as-is",
+            })
+
+    # -- class 3: ratio outliers --------------------------------------------
+    # These MUST be compared on genuinely corresponding paragraphs. Pairing by
+    # index does not work and silently produces nonsense: the reference splits a
+    # paragraph the output keeps whole (reference index 20 on getting_started.md),
+    # so everything after it is off by one and the class filled up with
+    # comparisons between an anchor line like `(install_anaconda)=` and an
+    # unrelated prose sentence. The two documents having the same paragraph count
+    # (156 each) was coincidence — offsetting splits and merges — so a count
+    # check does not detect it either.
+    #
+    # Alignment therefore runs on content: both renderings keep the same Latin
+    # technical tokens, URLs and code spans, so paragraphs are matched by Latin
+    # token overlap under a monotonicity constraint. Pairs below the similarity
+    # floor are reported as unalignable rather than guessed at.
+    rp, op = paragraphs(ref), paragraphs(out)
+    rr = [r for r in (ratio(p) for p in rp) if r is not None]
+    band_lo = statistics.quantiles(rr, n=10, method="inclusive")[0]
+    band_hi = statistics.quantiles(rr, n=10, method="inclusive")[-1]
+
+    pairs, align_stats = align_paragraphs(rp, op, floor=args.align_floor)
+    for i, j, sim in pairs:
+        a, b = rp[i], op[j]
+        ra, rb = ratio(a), ratio(b)
+        if ra is None or rb is None:
+            continue
+        delta = rb - ra
+        # Trigger on the DISAGREEMENT between the two renderings only.
+        #
+        # An earlier version also triggered when the output paragraph fell outside
+        # the reference's p10-p90 band, which is a guaranteed false-positive
+        # generator: by construction ~20% of any distribution lies outside its own
+        # p10-p90. Comparing the reference against itself produced 28 "outliers" on
+        # 151 paragraphs — pairs where the two renderings are byte-identical. Band
+        # membership is a distributional summary, not a per-paragraph acceptance
+        # range, so it is kept as annotation and never as a trigger.
+        if abs(delta) < args.delta_floor:
+            continue
+        findings.append({
+            "class": "ratio-outlier",
+            "reference_paragraph": i,
+            "output_paragraph": j,
+            "alignment_similarity": round(sim, 3),
+            "reference_ratio": round(ra, 3),
+            "output_ratio": round(rb, 3),
+            "delta": round(delta, 3),
+            "direction": "more Malayalam in output" if delta > 0 else "more English in output",
+            "outside_band": not (band_lo <= rb <= band_hi),
+            "score": int(abs(delta) * 20) + int(sim * 5),
+            "reference_text": a.replace("\n", " ").strip()[:400],
+            "output_text": b.replace("\n", " ").strip()[:400],
+            "resolves_to": "depends on direction",
+        })
+
+    class_rank = {"term-treatment": 0, "morphology": 1, "ratio-outlier": 2}
+    findings.sort(key=lambda f: (class_rank[f["class"]], -f["score"]))
+
+    # #228 ranks the classes 1-2-3, but filling the cap strictly in class order
+    # spends all thirty slots on classes 1 and 2 and puts *zero* ratio outliers to
+    # the reviewer — and the outliers are the sharpest items in the set (a
+    # paragraph the reference left wholly English and the output rendered 87%
+    # Malayalam is a better question than a single-occurrence suffix difference).
+    # So the cap is allocated as a quota per class, preserving the priority
+    # ordering while guaranteeing every class is represented. Unused quota flows
+    # to the next class so the cap is always filled.
+    quota = {"term-treatment": 8, "morphology": 12, "ratio-outlier": 10}
+    scale = args.cap / sum(quota.values())
+    budget = {k: max(1, round(v * scale)) for k, v in quota.items()}
+    selected, taken = [], {k: 0 for k in quota}
+    for cls in ("term-treatment", "morphology", "ratio-outlier"):
+        for f in findings:
+            if f["class"] != cls or taken[cls] >= budget[cls]:
+                continue
+            selected.append(f)
+            taken[cls] += 1
+    if len(selected) < args.cap:  # spill: fill remaining slots by class priority
+        chosen = {id(f) for f in selected}
+        for f in findings:
+            if len(selected) >= args.cap:
+                break
+            if id(f) not in chosen:
+                selected.append(f)
+    sel_ids = {id(f) for f in selected[: args.cap]}
+    ordered = selected[: args.cap] + [f for f in findings if id(f) not in sel_ids]
+    findings = ordered
+    for i, f in enumerate(findings):
+        f["rank"] = i + 1
+        f["above_cap"] = i < args.cap
+    quota_report = {"budget": budget, "taken": taken}
+
+    summary = {
+        "source": str(args.source),
+        "reference": str(args.reference),
+        "output": str(args.output),
+        "alignment": align_stats,
+        "reference_band": {"p10": round(band_lo, 3), "p90": round(band_hi, 3)},
+        "counts": {k: sum(1 for f in findings if f["class"] == k) for k in class_rank},
+        "total": len(findings),
+        "cap": args.cap,
+        "above_cap": min(args.cap, len(findings)),
+        "quota": quota_report,
+    }
+
+    if args.json:
+        print(json.dumps({"summary": summary, "findings": findings},
+                         ensure_ascii=False, indent=2))
+        return 0
+
+    print(json.dumps(summary, indent=2))
+    print()
+    for f in findings[: args.cap]:
+        if f["class"] == "term-treatment":
+            if f.get("cluster"):
+                print(f"[{f['rank']:2d}] term-treatment CLUSTER  {f['count']} ordinary words  "
+                      f"→ {f['resolves_to']}")
+                print(f"       kept English by reference, translated by output "
+                      f"({len(f['kept_english_by_reference'])}): "
+                      f"{', '.join(f['kept_english_by_reference'])}")
+                if f["kept_english_by_output"]:
+                    print(f"       kept English by output, translated by reference "
+                          f"({len(f['kept_english_by_output'])}): "
+                          f"{', '.join(f['kept_english_by_output'])}")
+            else:
+                print(f"[{f['rank']:2d}] term-treatment  {f['term']!r} "
+                      f"{f['surface_forms']}  src×{f['source_count']}  "
+                      f"ref×{f['reference_count']} out×{f['output_count']}  "
+                      f"kept-English-by={f['kept_english_by']}"
+                      f"{'  PINNED' if f['pinned'] else ''}")
+        elif f["class"] == "morphology":
+            if f.get("cluster"):
+                print(f"[{f['rank']:2d}] morphology CLUSTER  ({f['kind']})  "
+                      f"ref-only={f['reference_only_forms']} "
+                      f"out-only={f['output_only_forms']}  on {len(f['roots'])} roots: "
+                      f"{', '.join(f['roots'])}")
+            else:
+                print(f"[{f['rank']:2d}] morphology  {f['root']!r}  ({f['kind']})  "
+                      f"ref={f['reference_forms']}  out={f['output_forms']}")
+        else:
+            print(f"[{f['rank']:2d}] ratio-outlier  ref¶{f['reference_paragraph']}"
+                  f"/out¶{f['output_paragraph']} (sim {f['alignment_similarity']})  "
+                  f"ref={f['reference_ratio']} out={f['output_ratio']} "
+                  f"delta={f['delta']:+.3f}  {f['direction']}"
+                  f"{'  OUTSIDE-BAND' if f['outside_band'] else ''}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/ml-benchmark/scripts/divergences.py
+++ b/experiments/ml-benchmark/scripts/divergences.py
@@ -55,9 +55,28 @@ one two three first second next last e.g i.e etc via per""".split())
 
 
 def strip_to_prose(text: str) -> str:
-    """Drop fenced blocks and headings — the same convention ml_metrics.py uses."""
+    """Drop YAML frontmatter, fenced blocks and headings.
+
+    Follows `ml_metrics.py`'s convention, with one deliberate difference: the fence
+    pattern here also matches indented fences and runs of four or more backticks,
+    so it is a superset rather than an exact match. Frontmatter stripping was
+    missing until 2026-07-28 — every QuantEcon lecture opens with a jupytext
+    `---` block, so its Latin keys were being counted as prose. It changed no
+    finding on `getting_started.md` (term-treatment 4, morphology 26,
+    ratio-outlier 9 either way) because the block is identical in both renderings
+    and so cancels, but it inflated the paragraph count by one and could mask a
+    term-treatment divergence for any word the frontmatter also uses (`python`,
+    `language`, `name`).
+    """
+    lines = text.split("\n")
+    start = 0
+    if lines and lines[0].strip() == "---":
+        start = 1
+        while start < len(lines) and lines[start].strip() != "---":
+            start += 1
+        start += 1
     out, in_fence, marker = [], False, ""
-    for line in text.split("\n"):
+    for line in lines[start:]:
         m = FENCE.match(line)
         if m:
             tok = m.group(1)

--- a/experiments/ml-benchmark/scripts/passage_pairs.py
+++ b/experiments/ml-benchmark/scripts/passage_pairs.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Extract aligned English/Malayalam passage pairs from a structurally-identical pair of documents.
+
+Built for Stage 2 of #228 (the content-mix catalog) and reused by Stage 1's
+divergence inventory. The point of doing this in a script rather than by reading
+and retyping: Malayalam uses ZWJ/ZWNJ (U+200D/U+200C) in chillu formations, and
+copy-paste through an editor or a model's context can silently strip them. Every
+passage this emits is sliced byte-exact from the file, never retyped. See
+`reference/README.md` for the same hazard in the reference-commit procedure.
+
+Alignment assumes the two documents are structurally identical — which for the
+harness seeds is guaranteed by the #159 parity guard passing on write, and is
+re-asserted here rather than trusted.
+
+Usage:
+    python3 passage_pairs.py --source base-lecture.md --target base-lecture-ml.md
+    python3 passage_pairs.py --source a.md --target b.md --situation math --json
+"""
+
+import argparse
+import json
+import re
+import sys
+
+FENCE = re.compile(r'^\s*(`{3,})\{([\w-]+)\}')
+FENCE_PLAIN = re.compile(r'^\s*(`{3,})\s*$')
+HEADING = re.compile(r'^(#{1,6})\s+(.*)$')
+DOLLAR = re.compile(r'^\$\$\s*$')
+ML_RANGE = (0x0D00, 0x0D7F)
+
+
+def strip_frontmatter(text):
+    """Drop a leading YAML frontmatter block — jupytext metadata is not prose."""
+    if not text.startswith('---'):
+        return text
+    lines = text.split('\n')
+    for i in range(1, len(lines)):
+        if lines[i].strip() == '---':
+            return '\n'.join(lines[i + 1:])
+    return text
+
+
+def ml_codepoints(s):
+    return sum(1 for c in s if ML_RANGE[0] <= ord(c) <= ML_RANGE[1])
+
+
+def latin_letters(s):
+    return sum(1 for c in s if ('a' <= c <= 'z') or ('A' <= c <= 'Z'))
+
+
+def blocks(lines):
+    """Segment a document into typed blocks, tracking fenced regions.
+
+    Returns a list of dicts: {kind, name, start, end, lines}. `kind` is one of
+    heading / directive / mathfence / para / blank. Code and math fences are kept
+    whole so prose extraction never reaches inside one.
+    """
+    out = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        m = FENCE.match(line)
+        if m:
+            ticks, name = m.group(1), m.group(2)
+            j = i + 1
+            close = re.compile(r'^\s*`{%d,}\s*$' % len(ticks))
+            while j < n and not close.match(lines[j]):
+                j += 1
+            out.append({'kind': 'directive', 'name': name, 'start': i, 'end': min(j, n - 1),
+                        'lines': lines[i:min(j + 1, n)]})
+            i = j + 1
+            continue
+        if DOLLAR.match(line):
+            j = i + 1
+            while j < n and not DOLLAR.match(lines[j]):
+                j += 1
+            out.append({'kind': 'mathfence', 'name': '$$', 'start': i, 'end': min(j, n - 1),
+                        'lines': lines[i:min(j + 1, n)]})
+            i = j + 1
+            continue
+        h = HEADING.match(line)
+        if h:
+            out.append({'kind': 'heading', 'name': h.group(1), 'start': i, 'end': i,
+                        'lines': [line], 'text': h.group(2)})
+            i += 1
+            continue
+        if line.strip() == '':
+            i += 1
+            continue
+        # a paragraph runs to the next blank line or structural marker
+        j = i
+        while (j < n and lines[j].strip() != '' and not FENCE.match(lines[j])
+               and not DOLLAR.match(lines[j]) and not HEADING.match(lines[j])):
+            j += 1
+        out.append({'kind': 'para', 'name': None, 'start': i, 'end': j - 1, 'lines': lines[i:j]})
+        i = j
+    return out
+
+
+def signature(bs):
+    """Structural fingerprint used to assert the two documents align."""
+    return [(b['kind'], b['name']) for b in bs]
+
+
+def skeleton(bs):
+    """Directive / math / heading sequence — the real structural contract.
+
+    Paragraph counts legitimately differ between two independent translations
+    (a translator may split or merge a paragraph), so comparing every block
+    reports MISALIGNED on perfectly healthy documents. The skeleton is what the
+    engine's own structural-parity guard cares about, and what a mismatch here
+    would actually mean: a lost or transposed code cell, math block or heading.
+    """
+    return [(b['kind'], b['name']) for b in bs
+            if b['kind'] in ('directive', 'mathfence', 'heading')]
+
+
+def code_comments(block):
+    """Comment lines inside a code fence, with their offsets."""
+    res = []
+    for off, ln in enumerate(block['lines']):
+        s = ln.strip()
+        if s.startswith('#') and not s.startswith('#!'):
+            res.append((off, ln))
+    return res
+
+
+ADMONITIONS = ('note', 'hint', 'warning', 'tip', 'important', 'admonition',
+               'exercise', 'exercise-start', 'solution-start', 'epigraph', 'seealso')
+
+
+def emit_block_pair(pairs, a, b, i, bs=None):
+    """Append the passage pairs a single aligned block pair contributes.
+
+    Directive-anchored situations (heading, admonition, figure, code-comment) need
+    only that this pair corresponds. Prose situations additionally need the
+    surrounding paragraph sequence, so they are emitted only when `bs` is supplied.
+    """
+    if a['kind'] == 'heading':
+        pairs.append({'situation': 'heading', 'block': i,
+                      'source_line': a['start'] + 1, 'target_line': b['start'] + 1,
+                      'en': a['lines'][0], 'ml': b['lines'][0],
+                      'identical': a['lines'][0].rstrip() == b['lines'][0].rstrip()})
+        return
+    if a['kind'] == 'directive':
+        if a['name'] in ADMONITIONS:
+            pairs.append({'situation': 'admonition', 'directive': a['name'], 'block': i,
+                          'source_line': a['start'] + 1, 'target_line': b['start'] + 1,
+                          'en': '\n'.join(a['lines']), 'ml': '\n'.join(b['lines'])})
+        if a['name'] in ('figure', 'image'):
+            pairs.append({'situation': 'figure', 'directive': a['name'], 'block': i,
+                          'source_line': a['start'] + 1, 'target_line': b['start'] + 1,
+                          'en': '\n'.join(a['lines']), 'ml': '\n'.join(b['lines'])})
+        if a['name'] in ('code-cell', 'code-block'):
+            for (oa, la), (ob, lb) in zip(code_comments(a), code_comments(b)):
+                pairs.append({'situation': 'code-comment', 'block': i,
+                              'source_line': a['start'] + oa + 1,
+                              'target_line': b['start'] + ob + 1,
+                              'en': la, 'ml': lb,
+                              'identical': la.rstrip() == lb.rstrip(),
+                              'ml_codepoints': ml_codepoints(lb)})
+        return
+    if bs is None:
+        return
+    for sit in classify(bs, i):
+        pairs.append({'situation': sit, 'block': i,
+                      'source_line': a['start'] + 1, 'target_line': b['start'] + 1,
+                      'en': '\n'.join(a['lines']), 'ml': '\n'.join(b['lines']),
+                      'ml_codepoints': ml_codepoints('\n'.join(b['lines'])),
+                      'latin_letters': latin_letters('\n'.join(b['lines']))})
+
+
+def emit_text(report, pairs):
+    counts = {}
+    for p in pairs:
+        counts[p['situation']] = counts.get(p['situation'], 0) + 1
+    print(f"aligned={report['aligned']}  "
+          f"skeleton_identical={report['skeleton_identical']}  "
+          f"blocks={report['source_blocks']}")
+    print("situations: " + ', '.join(f'{k}={v}' for k, v in sorted(counts.items())))
+    print()
+    for p in pairs:
+        flag = ''
+        if 'identical' in p:
+            flag = '  [IDENTICAL]' if p['identical'] else '  [DIFFERS]'
+        print(f"--- {p['situation']}  en:{p['source_line']} ml:{p['target_line']}{flag}")
+        print(f"EN: {p['en']}")
+        print(f"ML: {p['ml']}")
+        print()
+
+
+def classify(bs, idx):
+    """Which content situations does block idx participate in?"""
+    b = bs[idx]
+    sits = []
+    if b['kind'] != 'para':
+        return sits
+    nxt = bs[idx + 1] if idx + 1 < len(bs) else None
+    if nxt and nxt['kind'] == 'mathfence':
+        sits.append('math-intro')
+    if nxt and nxt['kind'] == 'directive' and nxt['name'] == 'math':
+        sits.append('math-intro')
+    if nxt and nxt['kind'] == 'directive' and nxt['name'] in ('code-cell', 'code-block'):
+        sits.append('code-intro')
+    # depth of the most recent heading
+    depth = 0
+    for k in range(idx - 1, -1, -1):
+        if bs[k]['kind'] == 'heading':
+            depth = len(bs[k]['name'])
+            break
+    if depth >= 4:
+        sits.append('nested-subsection')
+    if not sits:
+        sits.append('plain-prose')
+    return sits
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--source', required=True)
+    ap.add_argument('--target', required=True)
+    ap.add_argument('--situation', default=None,
+                    help='math-intro | code-intro | nested-subsection | plain-prose | '
+                         'admonition | figure | code-comment | heading')
+    ap.add_argument('--json', action='store_true')
+    args = ap.parse_args()
+
+    src = strip_frontmatter(open(args.source, encoding='utf-8').read()).split('\n')
+    tgt = strip_frontmatter(open(args.target, encoding='utf-8').read()).split('\n')
+    bs, bt = blocks(src), blocks(tgt)
+
+    sig_s, sig_t = signature(bs), signature(bt)
+    skel_s, skel_t = skeleton(bs), skeleton(bt)
+    aligned = sig_s == sig_t
+    skeleton_ok = skel_s == skel_t
+    report = {'source': args.source, 'target': args.target,
+              'aligned': aligned, 'skeleton_identical': skeleton_ok,
+              'blocks': len(bs),
+              'source_blocks': len(bs), 'target_blocks': len(bt),
+              'source_skeleton': len(skel_s), 'target_skeleton': len(skel_t),
+              'pairs': []}
+
+    if not skeleton_ok:
+        # A skeleton mismatch is a real structural defect — a lost or transposed
+        # code cell, math block or heading. Refuse to emit pairs.
+        for k, (a, b) in enumerate(zip(skel_s, skel_t)):
+            if a != b:
+                report['skeleton_divergence'] = {
+                    'index': k, 'source': list(a), 'target': list(b)}
+                break
+        else:
+            report['skeleton_divergence'] = {
+                'index': min(len(skel_s), len(skel_t)),
+                'note': f'length differs: {len(skel_s)} vs {len(skel_t)}'}
+        msg = f"STRUCTURAL DEFECT: {report['skeleton_divergence']}"
+        print(json.dumps(report, ensure_ascii=False, indent=2) if args.json else msg,
+              file=sys.stderr)
+        return 2
+
+    if not aligned:
+        # Paragraph counts differ but the skeleton matches: a translator split or
+        # merged a paragraph. Benign, and common between independent renderings —
+        # so warn and carry on, emitting only the directive-anchored situations
+        # (headings, admonitions, figures, code comments), which do not depend on
+        # paragraph correspondence. Prose situations are suppressed because
+        # pairing them by index would be wrong; see REPORT.md "Method corrections".
+        report['note'] = ('paragraph structure differs but the skeleton is identical; '
+                          'emitting directive-anchored situations only')
+        print(f"NOTE: paragraph blocks differ ({len(bs)} vs {len(bt)}) but the "
+              f"structural skeleton is identical ({len(skel_s)} items) — emitting "
+              f"directive-anchored situations only", file=sys.stderr)
+        pairs = []
+        s_idx = [i for i, b in enumerate(bs)
+                 if b['kind'] in ('directive', 'mathfence', 'heading')]
+        t_idx = [i for i, b in enumerate(bt)
+                 if b['kind'] in ('directive', 'mathfence', 'heading')]
+        for si_, ti_ in zip(s_idx, t_idx):
+            emit_block_pair(pairs, bs[si_], bt[ti_], si_)
+    else:
+        pairs = []
+        for i, (a, b) in enumerate(zip(bs, bt)):
+            emit_block_pair(pairs, a, b, i, bs=bs)
+
+    if args.situation:
+        pairs = [p for p in pairs if p['situation'] == args.situation]
+    report['pairs'] = pairs
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        emit_text(report, pairs)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/experiments/ml-benchmark/scripts/passage_pairs.py
+++ b/experiments/ml-benchmark/scripts/passage_pairs.py
@@ -23,7 +23,9 @@ import re
 import sys
 
 FENCE = re.compile(r'^\s*(`{3,})\{([\w-]+)\}')
-FENCE_PLAIN = re.compile(r'^\s*(`{3,})\s*$')
+# Any fence opener that is NOT a `{directive}`: ```python, ~~~, or a bare ```.
+# Must be tried only after FENCE, which claims the braced form.
+FENCE_PLAIN = re.compile(r'^\s*(`{3,}|~{3,})([^\s{][^\n]*)?\s*$')
 HEADING = re.compile(r'^(#{1,6})\s+(.*)$')
 DOLLAR = re.compile(r'^\$\$\s*$')
 ML_RANGE = (0x0D00, 0x0D7F)
@@ -52,8 +54,11 @@ def blocks(lines):
     """Segment a document into typed blocks, tracking fenced regions.
 
     Returns a list of dicts: {kind, name, start, end, lines}. `kind` is one of
-    heading / directive / mathfence / para / blank. Code and math fences are kept
-    whole so prose extraction never reaches inside one.
+    heading / directive / codefence / mathfence / para. Code and math fences are
+    kept whole so prose extraction never reaches inside one.
+
+    `codefence` covers a fence with no `{directive}` — ```python, ~~~, or a bare
+    ```. Its `name` is the language tag if there is one, else None.
     """
     out = []
     i = 0
@@ -64,10 +69,28 @@ def blocks(lines):
         if m:
             ticks, name = m.group(1), m.group(2)
             j = i + 1
-            close = re.compile(r'^\s*`{%d,}\s*$' % len(ticks))
+            close = re.compile(r'^\s*%s{%d,}\s*$' % (re.escape(ticks[0]), len(ticks)))
             while j < n and not close.match(lines[j]):
                 j += 1
             out.append({'kind': 'directive', 'name': name, 'start': i, 'end': min(j, n - 1),
+                        'lines': lines[i:min(j + 1, n)]})
+            i = j + 1
+            continue
+        m = FENCE_PLAIN.match(line)
+        if m:
+            # A fence with no `{directive}` — ```python, ~~~, or a bare ```. Consumed
+            # whole, exactly like a directive: before this branch existed the opener
+            # fell through to the paragraph scan and the code inside was extracted as
+            # prose. No document in this experiment triggered it (every fence in the
+            # ml corpus is a braced MyST directive), but harness fixtures such as
+            # `23-special-chars-lecture.md` are all plain fences and would have been
+            # read as prose end to end.
+            ticks, lang = m.group(1), (m.group(2) or '').strip() or None
+            j = i + 1
+            close = re.compile(r'^\s*%s{%d,}\s*$' % (re.escape(ticks[0]), len(ticks)))
+            while j < n and not close.match(lines[j]):
+                j += 1
+            out.append({'kind': 'codefence', 'name': lang, 'start': i, 'end': min(j, n - 1),
                         'lines': lines[i:min(j + 1, n)]})
             i = j + 1
             continue
@@ -88,10 +111,13 @@ def blocks(lines):
         if line.strip() == '':
             i += 1
             continue
-        # a paragraph runs to the next blank line or structural marker
+        # A paragraph runs to the next blank line or structural marker. FENCE_PLAIN
+        # belongs in this list too: without it a paragraph immediately followed by
+        # ```python swallowed the fence and its code.
         j = i
         while (j < n and lines[j].strip() != '' and not FENCE.match(lines[j])
-               and not DOLLAR.match(lines[j]) and not HEADING.match(lines[j])):
+               and not FENCE_PLAIN.match(lines[j]) and not DOLLAR.match(lines[j])
+               and not HEADING.match(lines[j])):
             j += 1
         out.append({'kind': 'para', 'name': None, 'start': i, 'end': j - 1, 'lines': lines[i:j]})
         i = j
@@ -113,7 +139,7 @@ def skeleton(bs):
     would actually mean: a lost or transposed code cell, math block or heading.
     """
     return [(b['kind'], b['name']) for b in bs
-            if b['kind'] in ('directive', 'mathfence', 'heading')]
+            if b['kind'] in ('directive', 'mathfence', 'heading', 'codefence')]
 
 
 def code_comments(block):
@@ -128,6 +154,17 @@ def code_comments(block):
 
 ADMONITIONS = ('note', 'hint', 'warning', 'tip', 'important', 'admonition',
                'exercise', 'exercise-start', 'solution-start', 'epigraph', 'seealso')
+
+
+def emit_code_comments(pairs, a, b, i):
+    """Pair up the comment lines inside two corresponding code fences."""
+    for (oa, la), (ob, lb) in zip(code_comments(a), code_comments(b)):
+        pairs.append({'situation': 'code-comment', 'block': i,
+                      'source_line': a['start'] + oa + 1,
+                      'target_line': b['start'] + ob + 1,
+                      'en': la, 'ml': lb,
+                      'identical': la.rstrip() == lb.rstrip(),
+                      'ml_codepoints': ml_codepoints(lb)})
 
 
 def emit_block_pair(pairs, a, b, i, bs=None):
@@ -153,13 +190,11 @@ def emit_block_pair(pairs, a, b, i, bs=None):
                           'source_line': a['start'] + 1, 'target_line': b['start'] + 1,
                           'en': '\n'.join(a['lines']), 'ml': '\n'.join(b['lines'])})
         if a['name'] in ('code-cell', 'code-block'):
-            for (oa, la), (ob, lb) in zip(code_comments(a), code_comments(b)):
-                pairs.append({'situation': 'code-comment', 'block': i,
-                              'source_line': a['start'] + oa + 1,
-                              'target_line': b['start'] + ob + 1,
-                              'en': la, 'ml': lb,
-                              'identical': la.rstrip() == lb.rstrip(),
-                              'ml_codepoints': ml_codepoints(lb)})
+            emit_code_comments(pairs, a, b, i)
+        return
+    if a['kind'] == 'codefence':
+        # A plain fence carries comments worth reviewing just as a code-cell does.
+        emit_code_comments(pairs, a, b, i)
         return
     if bs is None:
         return
@@ -202,6 +237,8 @@ def classify(bs, idx):
     if nxt and nxt['kind'] == 'directive' and nxt['name'] == 'math':
         sits.append('math-intro')
     if nxt and nxt['kind'] == 'directive' and nxt['name'] in ('code-cell', 'code-block'):
+        sits.append('code-intro')
+    if nxt and nxt['kind'] == 'codefence':
         sits.append('code-intro')
     # depth of the most recent heading
     depth = 0
@@ -272,9 +309,9 @@ def main():
               f"directive-anchored situations only", file=sys.stderr)
         pairs = []
         s_idx = [i for i, b in enumerate(bs)
-                 if b['kind'] in ('directive', 'mathfence', 'heading')]
+                 if b['kind'] in ('directive', 'mathfence', 'heading', 'codefence')]
         t_idx = [i for i, b in enumerate(bt)
-                 if b['kind'] in ('directive', 'mathfence', 'heading')]
+                 if b['kind'] in ('directive', 'mathfence', 'heading', 'codefence')]
         for si_, ti_ in zip(s_idx, t_idx):
             emit_block_pair(pairs, bs[si_], bt[ti_], si_)
     else:

--- a/experiments/ml-benchmark/scripts/transliteration_check.py
+++ b/experiments/ml-benchmark/scripts/transliteration_check.py
@@ -103,9 +103,25 @@ TRANSLITERATIONS: dict[str, list[str]] = {
 
 
 def strip_to_prose(text: str) -> str:
-    """Drop fenced blocks and headings, matching ml_metrics.py's convention."""
+    """Drop YAML frontmatter, fenced blocks and headings.
+
+    Follows `ml_metrics.py`'s convention, with one deliberate difference: the fence
+    pattern here also matches indented fences and runs of four or more backticks,
+    so it is a superset rather than an exact match. Frontmatter stripping was
+    missing until 2026-07-28. It changed no output — a jupytext `---` block
+    contains no Malayalam and none of the targeted transliteration forms, so both
+    detectors were already blind to it — but the docstring claimed parity with
+    `ml_metrics.py`, which does strip it.
+    """
+    lines = text.split("\n")
+    start = 0
+    if lines and lines[0].strip() == "---":
+        start = 1
+        while start < len(lines) and lines[start].strip() != "---":
+            start += 1
+        start += 1
     out, in_fence, marker = [], False, ""
-    for line in text.split("\n"):
+    for line in lines[start:]:
         m = FENCE.match(line)
         if m:
             tok = m.group(1)

--- a/experiments/ml-benchmark/scripts/transliteration_check.py
+++ b/experiments/ml-benchmark/scripts/transliteration_check.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Detect Malayalam-script phonetic renderings of English terms — a policy violation for ml.
+
+The ml policy keeps technical terms in Latin script. Writing an English word out
+phonetically in Malayalam letters (`click` -> `ക്ലിക്ക്`) violates it, and #189 sets
+the target at zero instances. Until now this was the one check in the ml suite
+documented as *manual* ("top tokens listed for a transliteration scan") — and a
+manual scan missed a real instance: `ml_metrics.py` printed the top 30 Malayalam
+tokens of an Opus 5 rendering and `ക്ലിക്ക്` (6 occurrences) fell just below the
+cut, while every FAIL gate reported clean.
+
+Two detectors, because each has a blind spot the other covers:
+
+  targeted  — for each English term, look for its conventional Malayalam
+              transliteration(s). Catches a transliteration even when a native
+              reference uses the same one, which the novel-token detector cannot.
+  novel     — Malayalam tokens present in a rendering but absent from a native
+              reference translation of the same document. Needs no term list, so it
+              catches transliterations nobody thought to enumerate. Blind to any
+              form the reference also used.
+
+Neither is a substitute for a native reader; both are cheap enough to gate on.
+`--fail-on-hit` exits non-zero so this can sit in CI or graduate into
+`diff-checks.ts` (#189 Phase 3).
+
+Usage:
+    python3 transliteration_check.py --doc out.md [--doc other.md] \
+        [--reference ../reference/getting_started.md] [--source EN.md] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import re
+import sys
+from pathlib import Path
+
+MALAYALAM_TOKEN = re.compile(r"[ഀ-ൿ‌‍]+")
+FENCE = re.compile(r"^\s*(`{3,}|~{3,})")
+HEADING = re.compile(r"^#{1,6}\s")
+
+# Conventional Malayalam transliterations of the English vocabulary QuantEcon
+# lectures actually use. Longest-form-first within each entry: forms are matched
+# without overlap so that `ക്ലിക്ക്` is not also counted as `ക്ലിക്`.
+TRANSLITERATIONS: dict[str, list[str]] = {
+    "click": ["ക്ലിക്ക്", "ക്ലിക്"],
+    "select": ["സെലക്റ്റ്", "സെലക്ട്"],
+    "tab": ["ടാബ്"],
+    "cell": ["സെല്ല്", "സെൽ"],
+    "menu": ["മെന്യു", "മെനു"],
+    "kernel": ["കേർണൽ", "കെർണൽ"],
+    "browser": ["ബ്രൗസ്സർ", "ബ്രൗസർ"],
+    "dashboard": ["ഡാഷ്‌ബോർഡ്", "ഡാഷ്ബോർഡ്"],
+    "terminal": ["ടെർമിനൽ"],
+    "notebook": ["നോട്ട്‌ബുക്ക്", "നോട്ട്ബുക്ക്", "നോട്ബുക്ക്"],
+    "button": ["ബട്ടൺ"],
+    "icon": ["ഐക്കൺ", "ഐകൺ"],
+    "border": ["ബോർഡർ"],
+    "cursor": ["കഴ്സർ", "കർസർ"],
+    "mode": ["മോഡ്"],
+    "line": ["ലൈൻ"],
+    "port": ["പോർട്ട്"],
+    "toolbar": ["ടൂൾബാർ"],
+    "debugger": ["ഡീബഗ്ഗർ", "ഡീബഗർ"],
+    "download": ["ഡൗൺലോഡ്"],
+    "install": ["ഇൻസ്റ്റാൾ"],
+    "library": ["ലൈബ്രറി"],
+    "package": ["പാക്കേജ്"],
+    "code": ["കോഡ്"],
+    "program": ["പ്രോഗ്രാം"],
+    "file": ["ഫയൽ"],
+    "text": ["ടെക്സ്റ്റ്"],
+    "search": ["സെർച്ച്"],
+    "green": ["ഗ്രീൻ"],
+    "box": ["ബോക്സ്"],
+    "window": ["വിൻഡോ"],
+    "page": ["പേജ്"],
+    "option": ["ഓപ്ഷൻ"],
+    "setup": ["സെറ്റപ്പ്"],
+    "set": ["സെറ്റ്"],
+    "server": ["സെർവർ"],
+    "cloud": ["ക്ലൗഡ്"],
+    "output": ["ഔട്ട്പുട്ട്"],
+    "run": ["റൺ"],
+    "type": ["ടൈപ്പ്"],
+    "edit": ["എഡിറ്റ്"],
+    "copy": ["കോപ്പി"],
+    "paste": ["പേസ്റ്റ്"],
+    "version": ["വേർഷൻ"],
+    "system": ["സിസ്റ്റം"],
+    "default": ["ഡിഫോൾട്ട്"],
+    "extension": ["എക്സ്റ്റൻഷൻ"],
+    "split": ["സ്പ്ലിറ്റ്"],
+    "test": ["ടെസ്റ്റ്"],
+    "start": ["സ്റ്റാർട്ട്"],
+    "machine": ["മെഷീൻ"],
+    "plot": ["പ്ലോട്ട്"],
+    "figure": ["ഫിഗർ"],
+    "help": ["ഹെൽപ്പ്"],
+}
+
+
+def strip_to_prose(text: str) -> str:
+    """Drop fenced blocks and headings, matching ml_metrics.py's convention."""
+    out, in_fence, marker = [], False, ""
+    for line in text.split("\n"):
+        m = FENCE.match(line)
+        if m:
+            tok = m.group(1)
+            if not in_fence:
+                in_fence, marker = True, tok[0]
+            elif tok[0] == marker:
+                in_fence = False
+            continue
+        if in_fence or HEADING.match(line):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def count_without_overlap(text: str, forms: list[str]) -> dict[str, int]:
+    """Count each form, consuming matches so a longer form is never re-counted.
+
+    `ക്ലിക്` is a prefix of `ക്ലിക്ക്`; counting both naively double-counts every
+    occurrence. Forms are tried longest-first and matched text is blanked out.
+    """
+    counts: dict[str, int] = {}
+    haystack = text
+    for form in sorted(forms, key=len, reverse=True):
+        n = haystack.count(form)
+        if n:
+            counts[form] = n
+            haystack = haystack.replace(form, "\x00" * len(form))
+    return counts
+
+
+def targeted(prose: str) -> dict:
+    hits, total = {}, 0
+    for term, forms in TRANSLITERATIONS.items():
+        found = count_without_overlap(prose, forms)
+        if found:
+            n = sum(found.values())
+            hits[term] = {"count": n, "forms": found}
+            total += n
+    return {"total": total, "terms": hits}
+
+
+def novel(prose: str, ref_prose: str) -> dict:
+    ref = set(MALAYALAM_TOKEN.findall(ref_prose))
+    counts = collections.Counter(MALAYALAM_TOKEN.findall(prose))
+    fresh = {t: c for t, c in counts.items() if t not in ref}
+    return {
+        "distinct_tokens": len(counts),
+        "absent_from_reference": len(fresh),
+        "top": sorted(fresh.items(), key=lambda kv: (-kv[1], kv[0]))[:25],
+    }
+
+
+def latin_occurrences(source: str, term: str) -> int:
+    return len(re.findall(rf"\b{re.escape(term)}(?:s|es|ing|ed)?\b", source, re.I))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--doc", type=Path, action="append", required=True,
+                    help="translated document to check (repeatable)")
+    ap.add_argument("--reference", type=Path,
+                    help="native-speaker reference, enables the novel-token detector")
+    ap.add_argument("--source", type=Path,
+                    help="English source, to report how many occurrences were affected")
+    ap.add_argument("--fail-on-hit", action="store_true",
+                    help="exit non-zero if any targeted transliteration is found")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    ref_prose = strip_to_prose(args.reference.read_text(encoding="utf-8")) if args.reference else None
+    src_raw = args.source.read_text(encoding="utf-8") if args.source else None
+
+    report = {"documents": {}}
+    worst = 0
+    for doc in args.doc:
+        prose = strip_to_prose(doc.read_text(encoding="utf-8"))
+        entry = {"targeted": targeted(prose)}
+        if ref_prose is not None:
+            entry["novel"] = novel(prose, ref_prose)
+        if src_raw is not None:
+            for term, info in entry["targeted"]["terms"].items():
+                info["source_occurrences"] = latin_occurrences(src_raw, term)
+        report["documents"][str(doc)] = entry
+        worst = max(worst, entry["targeted"]["total"])
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        for name, entry in report["documents"].items():
+            t = entry["targeted"]
+            print(f"== {name}")
+            print(f"   targeted transliterations: {t['total']}")
+            for term, info in sorted(t["terms"].items(), key=lambda kv: -kv[1]["count"]):
+                src = info.get("source_occurrences")
+                frac = f" of {src} source occurrences" if src else ""
+                forms = ", ".join(f"{f}×{c}" for f, c in info["forms"].items())
+                print(f"     {term:12s} {info['count']:3d}{frac}   [{forms}]")
+            if "novel" in entry:
+                n = entry["novel"]
+                print(f"   Malayalam tokens absent from the reference: "
+                      f"{n['absent_from_reference']} of {n['distinct_tokens']} distinct")
+            print()
+
+    if args.fail_on_hit and worst:
+        print(f"FAIL: {worst} transliteration(s) found; ml policy target is 0",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/ml-glossary-programming/.gitignore
+++ b/experiments/ml-glossary-programming/.gitignore
@@ -1,0 +1,2 @@
+outputs/
+data/


### PR DESCRIPTION
Executes all three stages of #228 (the re-scoped Phase 1 of #189) and delivers the two artifacts its exit criteria name: `REPORT.md` for us and `PACKET.md` for Adisankar. Folds in #207's seed review as packet section B, so he is asked the four open #71 questions once rather than twice.

Experiment-only: everything here lands under `experiments/`, plus one line adding `__pycache__/` to `.gitignore` because `experiments/` now carries Python analysis scripts. No engine code, no workflows, nothing shipped.

## The headline is more reassuring than Stage 1 alone suggested

Across five domain-dense lectures and two models, **203 distinct technical terms were extracted and all 203 were kept in English** — zero rendered in Malayalam script, and only 6 of the 203 pinned in `glossary/ml.json`. Structure held on **all eleven renderings**, skeleton-identical to source including `numpy` at 165 structural items. Headings came back 27/27 identical on the native reference and all three renderings of the benchmark document.

That is much stronger evidence than the FAIL gate produces. Pinned-term retention checked **7** terms, because only 7 of the glossary's 52 occur in `getting_started.md` — a denominator worth stating out loud whenever "100% retention" is quoted.

## Three real defects the gates did not catch

**Systematic over-translation.** Every machine rendering sits above the native reference at every quantile of per-paragraph Malayalam share (Opus 5 arm mean 0.577 vs 0.485). Mann–Whitney U on 151 vs 150 paragraphs: **p = 6.1e-05**, replicating on an independent run at p = 0.0005. Paragraphs at ≥75% Malayalam go 10 → 31. Over-translation is the inverted primary risk #189 names for ml.

**The script-ratio gate is structurally unable to see it**, because it compares the output's *mean* against the reference's *p10–p90* interval — a point against a band wide enough to swallow almost anything. Filed as #229, not fixed here, per #228's instruction to keep incidental defects out of the phase. It matters because Phase 3 is scheduled to decide which of these metrics graduate into `diff-checks.ts`, and this one would carry its blind spot with it.

**Transliterations, against a policy target of zero.** `click`, `option`, `set` and `type` written phonetically in Malayalam script, in 3 of 11 renderings. The native reference has **none** across all 57 checked terms. `option` was transliterated 3 of 7 occurrences *within one document* — the consistency risk #70 names, first field instance. None of the four terms is pinned, which is what makes section C the highest-leverage part of the packet.

Confirmed by three independent scan lenses plus adversarial verification, zero refuted, and the load-bearing counts re-verified by grep. It does **not** replicate: Opus 5 produced 6 in one run of a document and 0 in another, so the occurrence is real and the rate is unknown — a #227 question.

## The best thing in the packet came from asking *what* differs, not *how much*

All nine substantial paragraph divergences run the same direction, with no counter-examples, and one construction explains most of them. The reference keeps an English verb in Latin script under a Malayalam light verb — `press ചെയ്യുക`, `click ചെയ്താൽ`, `close ആകും` — where the tool substitutes a native Malayalam verb: `അമർത്തുക`, `അടയ്ക്കുന്നു`, `പ്രവർത്തനക്ഷമമാകും`. So the packet asks **one rule question** instead of nine paragraph questions.

## Stage 3's method did not survive contact with ml, and that corrects a revision I made to #228

The `glossary-review` disagreement filter returned 10 candidates and **every one is a singular/plural or spacing variant** — `tuple`/`tuples`, `deadweight loss`/`dead weight loss` — the exact categories the skill's step 4 says to drop. Zero survive assessment.

The reason is structural rather than a bad run: the filter measures variation in translation *choice*, and ml's policy removes that choice for precisely the terms being extracted. Both models keep the term in English, so the recorded rendering *is* the English term and disagreement degenerates to which surface form each model wrote down. Within-role drift was equally empty at 4 and 2 items, all plural-only.

#228 was revised (with the reviewer's agreement) to add the probe run on the grounds that drift alone finds nothing and a single arm has no ranking axis. The first half held. The second was right for the wrong reason — neither one arm nor two has a ranking axis here, because the axis itself is empty for a keep-English language. The probe earned its ~$1.50 for what it *established* rather than what it ranked: the 203-term result, the `type` transliteration, and the fact that this mechanism should not be reached for again on a keep-English language. Section C became a frequency-ranked "which of these should we pin" list, motivated directly by all four transliterated terms being unpinned — three of them interface verbs that a terminology extractor never proposes, so no terminology-driven process would ever have protected them.

## Method corrections, recorded because each would have reached the reviewer

**Pairing paragraphs by index is invalid and fails silently.** The reference splits a paragraph the output keeps whole, so everything after index 20 was off by one and ten queued packet items compared an anchor line like `(install_anaconda)=` against unrelated prose. A count check does not detect this — both documents have exactly 156 prose paragraphs, because splits and merges offset. Replaced with content-anchored alignment (Needleman–Wunsch over Jaccard similarity of Latin-token sets, which survive translation): 145 of 156 aligned at mean similarity 0.781, with weak pairs reported rather than guessed.

**An identity test caught a guaranteed false-positive generator.** Running the divergence tool on the reference *against itself* produced 28 ratio outliers, because ~20% of any distribution lies outside its own p10–p90 and band membership had been made a trigger. Outliers now trigger on disagreement between renderings only: the identity test reads 0/0/0 and the real comparison drops 53 → 9, with 44 of the 53 having been pairs where the two renderings agreed.

**A strict block-signature check reported a structural defect on a healthy document.** `python_essentials` looked like the #118/#203 transposition class; it was a benign paragraph split (309 vs 308 blocks) with every code cell present and in order. Verified on the skeleton — directives, math fences, headings — which is what the engine's own parity guard cares about. The script now separates the two conditions.

**An LLM-fabricated annotation was caught before it entered the report.** The extraction model reported "transliterated variants also appear" for `key` in `python_essentials`; there are zero occurrences of `കീ` in either rendering. It would have become a fifth transliterated term. Consistent with #227's constraint that no LLM-judged metric gates anything.

## Corrections to previously recorded facts

`base-lecture-ml.md` has **7** markdown headings, not the 17 recorded in #207 and on #194 — ten of the seventeen are Python comments inside code cells, matching a naive `^#+\s` pattern. Display math is 4 blocks, not 8 (that counted `$$` fence *lines*). Neither seed contains any admonition or figure, so Stage 2's missing content situations were re-sourced from the Stage 3 lectures at no extra cost. And of **47 `{figure}` directives across the whole programming series, none carries caption prose**, so figure captions are a vacuous content situation and no question is asked about them. Also: #189's band p10 was 0.127 against PLAN.md's and #194's 0.132; PLAN.md is authoritative and #189 has been corrected.

## New scripts

All three quote by slicing rather than retyping, so Malayalam ZWJ/ZWNJ survive — the hazard `reference/README.md` documents for the reference commit applies to anything built from these documents.

| Script | Purpose |
|---|---|
| `divergences.py` | ranked, clustered, content-aligned divergence inventory with per-class quotas and a question cap |
| `transliteration_check.py` | targeted + novel-token transliteration detection, `--fail-on-hit` for CI or Phase 3 graduation |
| `passage_pairs.py` | byte-exact aligned passage extraction, separating skeleton parity from benign paragraph splits |

`transliteration_check.py` is the Phase 3 graduation candidate: it converts the one check that was documented as *manual* into a deterministic gate, and it is the check that found `ക്ലിക്ക്` where the manual top-30 token scan did not.

## Cost

**~$5.90 real against $3.20 reported** — inside the $4–8 the revised #228 predicted. `claude-opus-5` prices at $0.000 on every call while `claude-opus-4-8` prices correctly, so #230 is a stale pricing-table entry rather than a design problem.

## Not decided here

Model selection, per #228's scope and #227's ownership. The report carries an explicit section on this: the over-translation direction holds for all three renderings and its magnitude is reproducible across two Opus 5 runs, but the transliteration counts point the *opposite* way across models. Two metrics, opposite orderings, eleven renderings, no replicates — exactly the situation `bench/` exists to resolve.

Glossary changes, rule changes and the Phase 2 batch selection are also not decided here. They are what Adisankar's answers decide.

Refs #228, #189, #207, #227. Filed from this work: #229, #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
