### PR TITLE
dev: record the v0.25.0 release and shadow-gate validation

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -10,14 +10,13 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
 - **Week of 2026-07-27**: resume into Phase 2 per the work-plan issue (#198 — opened at
   Wave 1 close). First gate: reformulate the round-trip invariant
   ([`D-2026-07-24-tech-debt-audit-boundaries.md`](decisions/D-2026-07-24-tech-debt-audit-boundaries.md)).
-  v0.24.0 is cut; **v0.25.0 is prepared but not yet released** — PR #242 is open and the three
-  tags are uncut, so `@v0` still resolves to v0.24.0. Wave 2 of the audit
+  v0.25.0 is **released and deployed** (2026-08-04; below). Wave 2 of the audit
   (#169–#176 + backlog #177) remains available.
 - **Malayalam** — `ml` config landed in v0.24.0 (PR #71). The harness now drives it as a
   first-class third language and it passes 26/26. Its two seed reference translations are
   machine drafts awaiting native review (#207); the benchmark's Phase 1 (#194) is unrun.
 - **Glossary PR #69** (ja) — open, awaiting native review + a `LANGUAGE_CONFIGS` entry.
-- **#210 — merged to `main` and CONFIRMED end-to-end; lands in v0.25.0** (#214, 2026-07-26). Review
+- **#210 — merged to `main` and CONFIRMED end-to-end; shipped in v0.25.0** (#214, 2026-07-26). Review
   mode partitions source-PR deletions out before the F40 guard, reports a deletion-only PR with
   no model calls and an `editor` route, and gates a target deletion the source PR did not make
   as a blocker. Non-404 target-fetch failures now fail the run (the loop's catch-all is gone),
@@ -39,11 +38,24 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
   templates, #117 demand-driven bibliography backfill (turns previously-green runs red by
   design when a key resolves nowhere), #210 deletion partitioning (deletion-only PRs stop
   failing review), the #202 one-version E2E harness, #237 ml packet rulings and #241 fr
-  editor rules + glossary v1.1. Moving `@v0` deploys all of it estate-wide at once. Watch:
-  the first organic **fr** review after the tag move — the new register rules feed review
-  mode and could not be exercised locally (no fr harness lane). The deployed estate's sync
-  workflows were already hand-gated (#220, closed); this release makes `translate setup`
-  and every documented template ship the gated shape.
+  editor rules + glossary v1.1. **Released and deployed 2026-08-04**: #242 squash-merged
+  (`c74e3aa`), three tags cut, `@v0` peels to `c74e3aa`. Gated per AGENTS.md §4a at the tag
+  with a **scoped** run (scenario 01 × zh-cn/fa/ml — full matrix ran 78/78 at `main`
+  2026-07-25, and the fixtures carry zero `{cite}` keys so #117 is unexercisable on the
+  harness at any scope), then the `@v0` smoke after the tag move: both rounds green on all
+  three lanes, every verdict block `engineVersion: 0.25.0`. zh-cn/fa recommended
+  `auto-merge` clean both rounds; ml PASSed but routed `editor` on minor gating findings
+  both rounds — first field data on the #237 rules, worth watching. **The shadow gate is
+  field-validated** (Stage 4 of QuantEcon/project-translation#15): `auto-merge-mode:
+  shadow` on the zh-cn harness review workflow produced `wouldAutoMerge: true` in the
+  block, the workflow notice, and no action — PR left open. Two operational findings from
+  that validation: a `pull_request` run resolves its workflow from the PR's **frozen merge
+  ref**, so label-cycling never picks up a workflow edit (`update-branch` is the reliable
+  re-fire); and review mode updates its existing comment in place, so a re-review leaves
+  one comment. Watch: the first organic **fr** review after the tag move — the new
+  register rules feed review mode and could not be exercised locally (no fr harness lane).
+  The deployed estate's sync workflows were already hand-gated (#220, closed); this
+  release makes `translate setup` and every documented template ship the gated shape.
 
 - **#192 — the `\translate-resync` trust gate, CLOSED across all three rollout steps**
   (2026-07-26, #219 + QuantEcon/lecture-python-intro#805 +

--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -44,7 +44,7 @@ Roadmap detail lives in [PLAN.md](PLAN.md), not here.
   2026-07-25, and the fixtures carry zero `{cite}` keys so #117 is unexercisable on the
   harness at any scope), then the `@v0` smoke after the tag move: both rounds green on all
   three lanes, every verdict block `engineVersion: 0.25.0`. zh-cn/fa recommended
-  `auto-merge` clean both rounds; ml PASSed but routed `editor` on minor gating findings
+  `auto-merge` clean both rounds; ml passed but routed `editor` on minor gating findings
   both rounds — first field data on the #237 rules, worth watching. **The shadow gate is
   field-validated** (Stage 4 of QuantEcon/project-translation#15): `auto-merge-mode:
   shadow` on the zh-cn harness review workflow produced `wouldAutoMerge: true` in the

--- a/.dev/log/2026-08-04-v0250-release.md
+++ b/.dev/log/2026-08-04-v0250-release.md
@@ -1,0 +1,46 @@
+# 2026-08-04 — v0.25.0 released, deployed, and shadow-gate field-validated
+
+**What shipped**: #242 (squash `c74e3aa`) promoted `[Unreleased]` → `[0.25.0]`: #192 trust-gated
+workflow templates, #117 bibliography backfill, #210 deletion partitioning, #202 one-version E2E
+harness, #237 ml packet rulings, #241 fr editor rules + glossary v1.1. Three tags cut
+(`v0.25.0` annotated, `v0.25`, `v0` force-moved); `@v0` peels to `c74e3aa`; GitHub release
+published (title = tag, headline in notes body).
+
+**Gating**: §4a run at the tag, **scoped** — scenario 01 × zh-cn/fa/ml. Rationale for the scope:
+the full matrix ran 78/78 at `main` on 2026-07-25; #210 was separately E2E-verified (scenario 18
+× 3 lanes); the fixtures contain zero `{cite}` keys, so #117's new path cannot fire on the
+harness at any scope; everything since is prompt/glossary data. After the tag move, the
+`--action-ref v0 --scenarios 01` smoke re-ran the same shape through the floating tag. Both
+rounds: 3/3 syncs green, 3/3 reviews posting verdict blocks with `engineVersion: 0.25.0`.
+zh-cn/fa recommended `auto-merge` clean in both rounds; **ml routed `editor` on minor gating
+findings in both rounds** — first field data on the #237 register rules.
+
+**Shadow gate validated on the deployed path** (Stage 4 of QuantEcon/project-translation#15):
+`auto-merge-mode: 'shadow'` committed to the zh-cn harness review workflow (divergence
+documented in the workflow header; the E2E script strips it on every re-render). The re-review
+of test-translation-sync.zh-cn#701 produced `autoMergeMode: "shadow"`, `wouldAutoMerge: true`,
+`reviewedHeadSha` bound to the current head, the `##[notice]` line ("would auto-merge PR #701 …
+no action taken"), and the PR left open. The `would-auto-merge` output has no consumer step, so
+it is covered by unit tests; the notice is emitted by the same code path.
+
+**Two operational findings** (also in project-translation's harness.md):
+
+1. A `pull_request` run resolves its workflow file from the PR's **merge ref, which freezes at
+   PR creation** — two label-cycles after pushing the shadow edit both re-ran the pre-edit
+   workflow. `gh api -X PUT repos/…/pulls/N/update-branch` merges base into head, fires
+   `synchronize`, and the fresh merge ref carries the edit. Same mechanism as the
+   `gh run rerun` frozen-merge-SHA trap.
+2. Review mode **updates its existing PR comment in place**, so a re-review leaves exactly one
+   comment and the superseded verdict block is gone — capture blocks before re-firing when a
+   before/after comparison matters.
+
+**Release-flow note for the checklist**: `gh pr merge` and the floating-tag force-push are
+gated to humans in agent sessions (the agent-authored-PR approval gate); the exact-version tag
+push, `gh release create`, and the E2E script's PR churn are not. Sequence observed to work:
+agent stages PR + notes → human merges → agent tags/gates/releases → human force-pushes the
+floating tags → agent smokes.
+
+**Next on this thread**: fleet shadow rollout — `auto-merge-mode: 'shadow'` PRs to the five
+production editions' review workflows, starting Stage 4's ≥4-week calibration window; watch the
+first organic fr review (register-rule tolerance has no harness lane); ml's repeated
+`editor` routing is the first thing to check when shadow data starts accruing.


### PR DESCRIPTION
Records-only PR (no code): brings `.dev/STATE.md` in line with reality after the v0.25.0 release and adds the session log.

**What it records**: v0.25.0 is released *and deployed* — #242 merged (`c74e3aa`), three tags cut, `@v0` peels to the release commit; §4a gate at the tag (scoped, scenario 01 × 3 lanes) and the post-tag-move `@v0` smoke both green with `engineVersion: 0.25.0` in every verdict block; the Stage 4 shadow gate field-validated on the zh-cn harness lane (`wouldAutoMerge: true` recorded, PR left open, nothing acted). Also logs two operational findings: `pull_request` runs resolve the workflow from the frozen merge ref (label-cycling misses workflow edits; `update-branch` is the reliable re-fire), and review mode updates its comment in place.

Full narrative: `.dev/log/2026-08-04-v0250-release.md`. Program-side record: QuantEcon/project-translation#15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
