### PR TITLE
dev(ml): Adisankar's follow-up answers (F1–F3) — archive, dispositions, verification

### DIFF
--- a/experiments/ml-benchmark/DISPOSITIONS.md
+++ b/experiments/ml-benchmark/DISPOSITIONS.md
@@ -198,10 +198,94 @@ out as `test-translation-sync.ml` PRs for inline flagging.
 ## Next actions
 
 1. ~~Commit reply + parsed JSON + this report~~ (this PR)
-2. Follow-up to Adisankar: `malayalam-review-followup.md` (A5/A6/A7 with
-   sentences, B2 clarification) — email, same raw-file round-trip
+2. ~~Follow-up to Adisankar: `malayalam-review-followup.md` (A5/A6/A7 with
+   sentences, B2 clarification) — email, same raw-file round-trip~~ — returned
+   2026-08-06, all three resolved; see "Follow-up round" below
 3. Companion PR: rules rewrite + glossary v0.2.0 + regeneration evidence
 4. Phase 2 batch through `test-translation-sync.ml` after merge
 5. New issue: cultural-reference flagging (D2)
 6. Phase 3 carries: transliteration gate graduation (A14), judge calibration
    against B1/B3 renderings, A11 defects as seeded-violation test cases
+
+## Follow-up round (F1–F3) — returned 2026-08-06
+
+The three re-posed A5–A7 questions came back answered 3 of 3, closing the last
+open threads from the packet: every question either round asked is now resolved,
+and Phase 2's only remaining dependency is his inline review of
+`lecture-python-programming.ml` PRs 1–5.
+
+### Provenance and integrity
+
+| Check | Sent | Returned |
+|---|--:|--:|
+| Valid UTF-8 | yes | yes |
+| Malayalam codepoints (whole file) | 209 | 407 |
+| ZWJ / ZWNJ (whole file) | 0 / 0 | 0 / 0 |
+| Answer boxes filled | 0 of 3 | **3 of 3** |
+
+One difference the first round did not have: a single line of **our covering
+prose** came back reworded ("are now pinned to stay in English" → "are pinned
+keep-English") — outside any answer box, and git confirms the sent version had
+the former. Harmless (he tightened our sentence into our own jargon), but it
+means "returned exactly as sent" is a per-round observation, not an assumption:
+the outside-the-boxes diff is now part of the check.
+
+Files:
+
+- `malayalam-review-followup-answers-adisankar.md` — byte-exact copy of the
+  returned file
+- `malayalam-review-followup-answers-adisankar.json` — parsed answers
+  (`scripts/parse_responses.py --filled … --template malayalam-review-followup.md
+  --check-zw --json`)
+
+### Dispositions
+
+| ID | His ruling | Disposition |
+|---|---|---|
+| F1 | Both renderings wrong: "the cell with the flashing cursor" *identifies which cell*; correct form is the relative participle `flashing cursor ഉള്ള cell-ൽ` | **Rule change + live defect** — the post-packet regeneration still renders accompaniment; fix rides v0.3. His full sentence joins the example bank and the Phase 3 judge ground truth (third reviewer-supplied rendering, after B1/B3) |
+| F2 | `-നെക്കാൾ` is an acceptable colloquial variant of `-നെ അപേക്ഷിച്ച്`; `കുറച്ചു` must be dropped alongside it, since the suffix already carries the comparative | **Accepted as-is + narrow rule** — A6 formally reclassifies from suspected error to acceptable variant, as predicted above. All five delivered PRs scanned: zero instances of the banned stack |
+| F3 | (a) `-ൽ നിന്നും` correct and preferred for "selecting from"; (b) `list-ന് താഴെ` correct for "below the list" | **Accepted as-is** — A7's false-pairing hypothesis confirmed; both forms → regression inventory |
+
+### What verification against live output added
+
+- **F1 is reproducible, not historical.** The post-packet regeneration
+  (`arms/2026-08-03-postpacket-opus5/getting_started.md`) renders the sentence
+  `…flashing cursor-നോടൊപ്പം cell-ൽ appear ചെയ്യും` — the same accompaniment
+  reading, under the current rules, in a different model. The rule gap is
+  general: English "the N with X" as an identifying modifier → `X ഉള്ള N`. The
+  accompaniment rendering is a seeded-violation candidate for Phase 3.
+- **F2 compliance is already true of the batch.** The diffs of
+  lecture-python-programming.ml PRs 1–5 contain five comparative-suffix
+  sentences; none stacks `കുറച്ചു` (checked at paragraph level). Nothing to fix,
+  nothing for him to re-review.
+- **F3's exoneration is visible in the regeneration**, which renders the
+  sentence `menu items-ന്റെ list-ന് തൊട്ടു താഴെയുള്ള Code drop-down box-ൽ
+  നിന്ന്…` — near-verbatim his second natural form, with `തൊട്ടു` even
+  capturing "just below". The tool's `list-ന്` was the menu-items slot all
+  along; the packet compared two different grammatical slots, as suspected.
+
+### Watch list (seen, deliberately not acted on)
+
+- **`കൂടുതൽ` as load-bearing quantifier next to `-നെക്കാൾ`** ("more work
+  than", "gives more than") is *outside* the F2 ruling, which named only the
+  downtoner `കുറച്ചു`. The regeneration renders the F2 source sentence itself
+  this way (`option-നെക്കാൾ കൂടുതൽ work … ആവശ്യമാണ്`), and PR 4 (pandas) has
+  the same structure (`Series NumPy arrays-നേക്കാൾ കൂടുതൽ നൽകുന്നു`) — under
+  his active review, so the PR round adjudicates it organically. Extending the
+  ruling to `കൂടുതൽ` without evidence would repeat the A6 error in the other
+  direction.
+- **`നിന്ന്` vs `നിന്നും`** — he calls `-ൽ നിന്നും` "preferred"; the tool
+  writes `-ൽ നിന്ന്` throughout the five PRs. Soft-watch: if it matters, it
+  surfaces as an inline flag.
+
+### Sequencing
+
+No standalone release and no re-regeneration now: the F1 rule/example change,
+the `കുറച്ചു` constraint, and the F3 morphology examples fold into **v0.3 with
+the PR-review flags**, exactly as the batch sequencing above records. Nothing
+further is owed to the reviewer; the acknowledgement says so explicitly.
+
+Calibration note for the record: F1 is the third time he has ruled against his
+own reference (A2, the B1/B3 reorderings, now the `-ഉം` cursor sentence). The
+reference remains strong ground truth held by an adjudicating, not defending,
+reviewer.

--- a/experiments/ml-benchmark/malayalam-review-followup-answers-adisankar.json
+++ b/experiments/ml-benchmark/malayalam-review-followup-answers-adisankar.json
@@ -1,0 +1,42 @@
+{
+  "source": "malayalam-review-followup-answers-adisankar.md",
+  "questions": 3,
+  "answered": 3,
+  "blank": [],
+  "unexpected_ids": [],
+  "answers": {
+    "F1": "Neither `-ഉം` nor `-നൊപ്പം` fits. Both miss the \"which cell\" reading. The cursor is identifying which cell is active, not appearing alongside the typed text.\n\nMy preferred rendering:\n\n`ഈ mode-ൽ നിങ്ങൾ എന്ത് type ചെയ്താലും അത് flashing cursor ഉള്ള cell-ൽ നിങ്ങൾക്ക് കാണാം`\n\n`flashing cursor ഉള്ള cell-ൽ` — \"in the cell that has the flashing cursor\" — correctly identifies which cell rather than implying the cursor appears alongside the typing.",
+    "F2": "Both forms are acceptable for a comparative sentence.\n\n`-നെ അപേക്ഷിച്ച്` is the more formal version and works with `കുറച്ചു` — `option-നെ അപേക്ഷിച്ച്, local installs കുറച്ചു പ്രയാസമാണ്`\n\n`-നെക്കാൾ` is the shorter colloquial version and is also acceptable — but `കുറച്ചു` must be dropped when using it, since `-നെക്കാൾ` already carries the comparative meaning. \n\nCorrect form: `option-നെക്കാൾ, local installs പ്രയാസമാണ്`\n\nFor classroom use either is fine. If the tool defaults to `-നെക്കാൾ`, please ensure `കുറച്ചു` is not retained alongside it.",
+    "F3": "(a) Yes — `-ൽ നിന്നും` is the correct and preferred suffix for \"selecting from\" something. `drop-down list-ൽ നിന്നും` is natural.\n\n(b) Yes — `list-ന് താഴെ` is correct for \"below the list.\"\n\nTwo natural Malayalam forms work here:\n\n`menu items list-ന് താഴെ` — \"below the menu items list\"\n`menu items-ന്റെ list-ന് താഴെ` — \"below the list of menu items\"\n\nBoth are acceptable. "
+  },
+  "zero_width": {
+    "answers_with_malayalam": [
+      {
+        "id": "F1",
+        "malayalam_chars": 58,
+        "zwj": 0,
+        "zwnj": 0,
+        "atomic_chillu": 5
+      },
+      {
+        "id": "F2",
+        "malayalam_chars": 102,
+        "zwj": 0,
+        "zwnj": 0,
+        "atomic_chillu": 4
+      },
+      {
+        "id": "F3",
+        "malayalam_chars": 38,
+        "zwj": 0,
+        "zwnj": 0,
+        "atomic_chillu": 2
+      }
+    ],
+    "totals": {
+      "zwj": 0,
+      "zwnj": 0,
+      "malayalam_chars": 198
+    }
+  }
+}

--- a/experiments/ml-benchmark/malayalam-review-followup-answers-adisankar.md
+++ b/experiments/ml-benchmark/malayalam-review-followup-answers-adisankar.md
@@ -1,0 +1,125 @@
+# Malayalam review — three sentences you asked for
+
+**Date**: 2026-08-03 · **Follow-up to**: the 23-question packet · **Tracking**: #189.
+
+Thank you — all 23 answers arrived intact (we byte-checked the Malayalam: nothing
+was stripped in transit) and every one of them is already turned into a rule
+change, a glossary entry, or a confirmed defect. In particular: the light-verb
+rule (A9) is now the tool's default for software actions, `click`/`option`/`set`/
+`type`/`press` are pinned keep-English, keyboard instructions normalise to
+`press ചെയ്യുക` (A8), code comments stay English (B4), and the Phase 2 batch is
+the five lectures you chose (D1) — they will arrive as pull requests once the
+rule changes are verified.
+
+You asked to see the full sentences behind A5–A7 before ruling, and you were right
+to: with the sentences in hand, **two of our three suspicions look like our errors,
+not the tool's**. The three questions, properly posed this time. Same format as
+before — type inside the boxes, return this `.md` file itself.
+
+---
+
+## F1 (was A5) — cursor
+
+> **English source**: In this mode, whatever you type will appear in the cell with
+> the flashing cursor.
+>
+> **Your translation**: ഈ mode-ൽ, നിങ്ങൾ എന്ത് type ചെയ്താലും അത് ഈ cell-ൽ കാണാം,
+> കൂടെ ഒരു flashing cursor-ഉം.
+>
+> **The tool**: …`cursor-നൊപ്പം` (its full sentence was not preserved — our
+> mistake, fixed for future rounds).
+
+One thing we noticed on re-reading the English: "the cell with the flashing
+cursor" is probably *identifying which cell* (the cell **that has** the cursor),
+rather than saying the typing appears *alongside* a cursor. If that reading is
+right, both renderings may miss it.
+
+**F1. Which case fits here — `-ഉം`, `-നൊപ്പം`, or something else entirely given
+the "which cell" reading?**
+
+```answer F1
+Neither `-ഉം` nor `-നൊപ്പം` fits. Both miss the "which cell" reading. The cursor is identifying which cell is active, not appearing alongside the typed text.
+
+My preferred rendering:
+
+`ഈ mode-ൽ നിങ്ങൾ എന്ത് type ചെയ്താലും അത് flashing cursor ഉള്ള cell-ൽ നിങ്ങൾക്ക് കാണാം`
+
+`flashing cursor ഉള്ള cell-ൽ` — "in the cell that has the flashing cursor" — correctly identifies which cell rather than implying the cursor appears alongside the typing.
+```
+
+## F2 (was A6) — option: our suspicion was wrong
+
+> **English source**: At the same time, local installs require more work **than** a
+> cloud option like Colab.
+>
+> **Your translation**: എന്നാൽ അതേ സമയം, Colab പോലുള്ള ഒരു cloud option-നെ
+> അപേക്ഷിച്ച്, local installs കുറച്ചു പ്രയാസമാണ്.
+>
+> **The tool**: …`option-നെക്കാൾ`…
+
+We told you we suspected a comparative where the source is not comparative. The
+source **is** comparative — "more work than". Our apology for the bad premise;
+your instinct to ask for the sentence was better calibrated than our suspicion.
+So the real question is the opposite of what we asked:
+
+**F2. With a comparative source, is the tool's `-നെക്കാൾ` an acceptable variant of
+your `-നെ അപേക്ഷിച്ച്` — or still wrong for some other reason?**
+
+```answer F2
+Both forms are acceptable for a comparative sentence.
+
+`-നെ അപേക്ഷിച്ച്` is the more formal version and works with `കുറച്ചു` — `option-നെ അപേക്ഷിച്ച്, local installs കുറച്ചു പ്രയാസമാണ്`
+
+`-നെക്കാൾ` is the shorter colloquial version and is also acceptable — but `കുറച്ചു` must be dropped when using it, since `-നെക്കാൾ` already carries the comparative meaning. 
+
+Correct form: `option-നെക്കാൾ, local installs പ്രയാസമാണ്`
+
+For classroom use either is fine. If the tool defaults to `-നെക്കാൾ`, please ensure `കുറച്ചു` is not retained alongside it.
+```
+
+## F3 (was A7) — list: possibly two different lists
+
+> **English source**: (You can also use your mouse to select `Markdown` from the
+> `Code` drop-down **box** just below the **list** of menu items)
+>
+> **Your translation**: (നിങ്ങളുടെ mouse ഉപയോഗിച്ച്, `Code` drop-down list-ൽ നിന്നും
+> `Markdown` select ചെയ്യാവുന്നതാണ്.)
+>
+> **The tool**: …`list-ന്`… (full sentence not preserved)
+
+The English sentence contains two list-like nouns: the drop-down itself, and the
+list of menu items it sits below. Your `list-ൽ` renders the drop-down. The tool's
+dative `list-ന്` may well have been part of "below the list of menu items"
+(`list-ന് താഴെ`) — a different noun in a different slot, in which case our
+comparison paired things that were never parallel.
+
+**F3. Two small rulings, so the rule generalises: (a) "from the drop-down" —
+is `-ൽ നിന്നും` the form to prefer? (b) "just below the list" — is `list-ന് താഴെ`
+correct there?**
+
+```answer F3
+(a) Yes — `-ൽ നിന്നും` is the correct and preferred suffix for "selecting from" something. `drop-down list-ൽ നിന്നും` is natural.
+
+(b) Yes — `list-ന് താഴെ` is correct for "below the list."
+
+Two natural Malayalam forms work here:
+
+`menu items list-ന് താഴെ` — "below the menu items list"
+`menu items-ന്റെ list-ന് താഴെ` — "below the list of menu items"
+
+Both are acceptable. 
+```
+
+---
+
+## B2, closed — with the clarification you asked for
+
+By "read more plainly" we meant: should prose nested deep in subsections use
+*simpler, more-Malayalam* language than top-level prose — some style guides ask
+for that. Your answer already settles it: the same register applies everywhere.
+Nothing more needed from you on this one.
+
+---
+
+That is the whole follow-up. Your chosen lectures are next; they will reach you as
+pull requests where you can comment on any line. Thank you again.


### PR DESCRIPTION
Adisankar returned the follow-up round (F1–F3, the re-posed A5–A7 case-grammar questions) on 2026-08-06 — 3 of 3 answered. This archives the reply byte-exact with parsed JSON and appends the F-round section to DISPOSITIONS.md: provenance, dispositions, verification against live output, and a watch list. With this, every question either round asked is resolved; Phase 2 waits solely on his inline review of lecture-python-programming.ml PRs 1–5.

**F1 (was A5) — rule change + live defect.** Both earlier renderings were wrong: "the cell with the flashing cursor" *identifies which cell*, and the correct form is the relative participle `flashing cursor ഉള്ള cell-ൽ`. The post-packet regeneration still renders accompaniment (`cursor-നോടൊപ്പം`) under the current rules, so this is a reproducible gap, not a historical one. His full sentence joins the example bank and the Phase 3 judge ground truth; the fix rides v0.3 with the PR-review flags — no standalone release.

**F2 (was A6) — accepted as-is + narrow rule.** `-നെക്കാൾ` is a valid colloquial variant of the reference's `-നെ അപേക്ഷിച്ച്`; the one hard instruction is that `കുറച്ചു` drops alongside it. All five delivered PR diffs scanned at paragraph level: zero instances of the banned stack, so the batch under review is already compliant. The `കൂടുതൽ`-as-quantifier structure (present in PR 4) is outside his ruling and deliberately watch-listed for the organic PR round rather than ruled on.

**F3 (was A7) — accepted as-is.** Both forms validated (`-ൽ നിന്നും` for "selecting from", `list-ന് താഴെ` for "below"), and the regeneration renders the sentence near-verbatim as his second natural form — confirming the packet had paired two different grammatical slots. No tool defect ever existed here.

Provenance is clean (valid UTF-8, ZWJ/ZWNJ 0/0, +198 Malayalam codepoints, 3/3 boxes) with one recorded oddity: a line of our covering prose came back reworded outside the answer boxes, so "returned exactly as sent" is now checked per round rather than assumed.

Refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
