### PR TITLE
E2E reset lays down .translate/config.yml with the production editors block

### DIFF
--- a/tool-test-action-on-github/test-action-on-github.sh
+++ b/tool-test-action-on-github/test-action-on-github.sh
@@ -561,6 +561,26 @@ for L in "${LANGUAGES[@]}"; do
         cp "$DATA_DIR/base-config.yml" "_config.yml"
         cp "$DATA_DIR/base-references-target.bib" "references.bib"
 
+        # Production editions all carry `.translate/config.yml` with an
+        # `editors:` block (project-translation#24), so the harness does too —
+        # block style with `primary:` first, the only form readConfig parses,
+        # and the shape writeConfig's unknown-key merge (#246) must preserve
+        # across bootstrap rewrites. The handle is deliberately mmcky rather
+        # than an edition's real editor: verdict-driven routing (#103) will
+        # read this block, and a harness run must never assign or ping a real
+        # editor from a test repo (nor could it — they are not collaborators
+        # here). tool-version is left absent until a CLI write stamps it;
+        # readConfig does not require it, and a hardcoded pin would go stale.
+        mkdir -p .translate
+        cat > .translate/config.yml <<EOF
+source-language: en
+target-language: $code
+docs-folder: .
+editors:
+  primary: mmcky
+  secondary: []
+EOF
+
         render_target_workflows
         assert_no_placeholders
 

--- a/tool-test-action-on-github/test-action-on-github.sh
+++ b/tool-test-action-on-github/test-action-on-github.sh
@@ -563,9 +563,13 @@ for L in "${LANGUAGES[@]}"; do
 
         # Production editions all carry `.translate/config.yml` with an
         # `editors:` block (project-translation#24), so the harness does too —
-        # block style with `primary:` first, the only form readConfig parses,
-        # and the shape writeConfig's unknown-key merge (#246) must preserve
-        # across bootstrap rewrites. The handle is deliberately mmcky rather
+        # block style with `primary:` first. That shape is not for the
+        # engine's own readConfig (js-yaml, style- and order-agnostic): it is
+        # what the status-translations collector's line-based parser requires,
+        # which returns None on the flow form and would take the first
+        # `- handle` of a leading `secondary:` list as primary. It is also the
+        # shape writeConfig's unknown-key merge (#246) must preserve across
+        # bootstrap rewrites. The handle is deliberately mmcky rather
         # than an edition's real editor: verdict-driven routing (#103) will
         # read this block, and a harness run must never assign or ping a real
         # editor from a test repo (nor could it — they are not collaborators


### PR DESCRIPTION
Closes the last item on QuantEcon/project-translation#24: the harness should mirror production's `.translate/config.yml`, which since 2026-08-18 carries an `editors:` block in all six live editions.

**What was actually diverging**: the #202 E2E overhaul deletes `.translate/` on every target reset and nothing re-creates it, so the harness targets have been running with *no* translate config at all — not just a missing `editors:` block. This change makes the reset lay the config down per target (`source-language`/`target-language`/`docs-folder: .` per the harness's root-level layout, plus the block).

Three deliberate choices, each commented in the script:

- **Block-style YAML, `primary:` first** — the only form the parser reads, and the shape `writeConfig`'s unknown-key merge (#246) must preserve. With this in the base state, any future CLI bootstrap driven against the harness exercises key survival as a standing regression check.
- **`primary: mmcky`, not the edition's real editor** — verdict-driven routing (#103) will read this block, and a harness run must never assign or ping a real editor from a test repo (nor could it; they are not collaborators there).
- **No `tool-version`** — `readConfig` does not require it, a hardcoded pin would go stale, and its absence until a CLI write stamps it is the true state.

The three test targets have also been given the same config by direct commit (authorised maintenance), so the live harness mirrors production immediately; the next E2E run would previously have wiped that, and with this change re-creates it instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
