### PR TITLE
dev: STATE.md — #276 measured and repaired, W1 → v0.27.0, v0.26.0 gate verified complete

### DIFF
--- a/.dev/STATE.md
+++ b/.dev/STATE.md
@@ -1,4 +1,4 @@
-verified: 2026-08-11
+verified: 2026-08-19
 
 # STATE
 
@@ -11,8 +11,9 @@ Roadmap detail lives in the work-plan tracker **#257**, not here (PLAN.md predat
   encoded (ml glossary v0.3.0 + 18-rule set, #272; regeneration-verified, #273), plus
   verdict provenance (#247), config-preserving writers (#243), newline-terminated
   writers (#266/#267), harness scenario 27, and the resync-gate `startsWith` alignment.
-  §4a gate pending post-merge: tag → E2E `--action-ref v0.26.0` → floating tags →
-  `@v0` smoke → GitHub release. The ml calibration programme is now
+  §4a gate **completed 2026-08-17** (verified 2026-08-19: harness scenario PRs
+  02:36 → GitHub release Latest 02:50; `@v0` = `v0.26` = `e4e5710`, so the alias
+  moved — no #109-class lag this time). The ml calibration programme is now
   one-lecture-per-round: stale seeds ml#2–#5 closed, round 2 open (ml#7, `functions`,
   engine `8625221`).
 - **The standing plan is tracker #257** (2026-08-10 backlog review; supersedes #94/#198):
@@ -32,14 +33,36 @@ Roadmap detail lives in the work-plan tracker **#257**, not here (PLAN.md predat
   and the test source repo carries only the zh-cn sync workflow until the next
   unscoped harness run.
 - **W1 (#259) is the next P0** — declared-vs-delivered assertion + TOC structured merge,
-  v0.26.0. Fully unblocked; the one gate is #169 first or alongside.
+  now targeting **v0.27.0** (v0.26.0 shipped 2026-08-17 as the ml round-1 release).
+  Fully unblocked; the one gate is #169 first or alongside. Scope grew 2026-08-19:
+  a stale-resync detection box (#276 guard — code cells modulo localized
+  comments/docstrings) and the both-directions rule on the assertion (`files[]`
+  under-declares: bib + state delivered undeclared).
+- **#276 (sixth instance of the class, resync path)** — `\translate-resync`
+  regenerates from the source PR's merge-time snapshot; fired in the field
+  2026-08-18. Fully measured 2026-08-19 (ledger in #276): zh-cn clean; fr numpy
+  missed #595 (regeneration silently dropped the file — second mechanism); fa two
+  stale state files + a pandas_panel divergence the hand-restore introduced.
+  Repair PRs open: fa#158, fr#38. **Resync moratorium until the guard lands.**
 - **Malayalam** — first-class harness language (26/26); its two seed reference
   translations await native review (#207); benchmark Phase 1 (#194) unrun.
 - **Glossary PR #69** (ja) — open, awaiting native review + a `LANGUAGE_CONFIGS` entry.
 
 ## Recently landed
 
-- **2026-08-11 — W0 S-fixes** (this change): #230 `claude-opus-5` pricing entry
+- **2026-08-19 — #276 triaged, measured, and repairs opened** (this change): labels
+  + tracker/W1 bodies updated in place (sixth instance; W1 → v0.27.0; guard box with
+  the localized-docstring caveat; label migration marked done-verified). Full
+  recorded-vs-actual measurement of all 21 state files across fa/fr/zh-cn plus
+  content probes — three first-pass claims reversed: zh-cn needs nothing, the fa
+  pandas_panel "restore" (fa#155) itself diverged from source, and fr numpy's gap is
+  a silent per-file drop by the regeneration, not stale state. Repair PRs:
+  lecture-python-programming.fa#158 (two state files + pandas_panel URL form),
+  lecture-python-programming.fr#38 (hand-port of the two #595 numpy edits — never
+  `forward` a natively-reviewed lecture). Settle-week interaction checked: the
+  workspace-lectures republish→delete sequence is unblocked (pandas/polars byte-clean
+  on all three targets).
+- **2026-08-11 — W0 S-fixes**: #230 `claude-opus-5` pricing entry
   ($5/$25/MTok; Opus 5 spend had reported as $0.000) + warn-once on unpriced models +
   `VALID_MODEL_PATTERNS` gains opus-5/fable-5; #234.4 resync gate aligned to the
   parser's `startsWith` across the scaffolder, all docs, and the harness template;
@@ -74,10 +97,11 @@ Roadmap detail lives in the work-plan tracker **#257**, not here (PLAN.md predat
 
 ## Next
 
-- **W1 (#259)**: declared-vs-delivered + TOC merge, with #169 first/alongside. Fold in
-  the 2026-08-11 finding: metadata `files[]` must declare everything delivered (bib,
-  state), not just the markdown — reconcile both directions.
+- **W1 (#259)**: #169 first/alongside, then the boxes — declared-vs-delivered (both
+  directions, folded into the body 2026-08-19), TOC merge, partial-PR annotation,
+  #276 guard.
 - **D1** at W2 (#260) kickoff — start the editions-side conversation early.
+- **Merge the #276 repair PRs** (fa#158, fr#38) and hold the resync moratorium.
 - **Watch**: first organic fr review (register rules); first organic sync batch after
   v0.25.0 (#117 backfill turns missing-bib-key runs red by design).
 - **W4 prompt work** waits for the shadow-freeze lift (~2026-09-01); any model change
@@ -88,9 +112,9 @@ Roadmap detail lives in the work-plan tracker **#257**, not here (PLAN.md predat
 - `main` green; 1,516 tests (64 suites, zero skips, type-checked), lint at
   `--max-warnings 0` including root `*.mjs`, CI checks formatting and `.dev/`
   path:line references.
-- Highest-priority known bug class: silent partial delivery (#90 defects 3–5 as a
-  class, freshest instance 2026-08-10 fr#29 — reported success, no error recorded).
-  W1 is its detection layer.
+- Highest-priority known bug class: the success-shaped failure (#90 defects 3–5 plus
+  #276's two resync mechanisms; freshest instance 2026-08-18, stale regeneration
+  merged on fa). W1 is its detection layer.
 - Prod dep advisories: **0**. ESM-only `@actions/*` 3.x/9.x majors tracked as
   #177 F35.
 


### PR DESCRIPTION
STATE.md refresh for the 2026-08-19 session, all claims verified before writing:

**#276 (stale resync)** — triaged as the class's sixth field instance (`bug` + `high-priority`; tracker #257 and W1 #259 bodies updated in place). The full measurement — recorded `source-sha` vs the source's true last-touch commit for all 21 state files across fa/fr/zh-cn, plus content probes for every #595/#612 edit — reversed three first-pass claims: zh-cn needs nothing (its original batch PR had merged; the stale regeneration was correctly discarded), the fa pandas_panel hand-restore itself introduced a three-line divergence from source (the batch had legitimately changed the source's URL form), and fr numpy's gap is a silent per-file drop by the regeneration, a second failure mechanism distinct from the stale snapshot. Repair PRs are open: state + URL-form restore in lecture-python-programming.fa#158, and the hand-port of the two numpy edits in lecture-python-programming.fr#38 (hand-ported because numpy.md is natively reviewed — whole-file `forward` would discard the review).

**W1 (#259)** — retargeted v0.27.0 (v0.26.0 shipped 2026-08-17 as the ml round-1 release), scope grown by the #276 guard box (code-cell invariance modulo localized comments/docstrings — fa/zh-cn localize them, fr does not, measured on numpy.md) and the both-directions declared-vs-delivered rule. Gate unchanged: #169 first or alongside.

**v0.26.0 §4a gate** — the previous STATE said "pending post-merge"; verified today it completed on 2026-08-17: harness scenario PRs at 02:36, GitHub release (Latest) at 02:50, and `@v0` = `v0.26` = `e4e5710`, so the alias moved with the release — no repeat of the #109-class tag lag.

Also records the settle-week interaction check: the workspace-lectures republish→delete sequence is unblocked (pandas/polars byte-clean on all three targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
